### PR TITLE
test: add 84 IDapperService tests without DB and fix critical Rollbac…

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,46 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.8.2] - 2026-06-19
+
+### Fixed
+
+- **Critical: RollbackTransaction destroyed the entire transaction when rolling back a
+  savepoint.** Previously, when a savepoint was active, `RollbackTransaction` issued the
+  `ROLLBACK TRANSACTION <savepoint>` command but then unconditionally called
+  `CleanupTransaction()` in a `finally` block, which disposed the entire outer transaction and
+  cleared the savepoint stack. This meant that nested rollback not only undid the work since
+  the savepoint but also rolled back the entire transaction. Now, savepoint rollback returns
+  early without disposing the outer transaction (mirroring the behaviour of `CommitTransaction`).
+
+- **ConnectionManager now opens external connections when needed.** Previously, when an
+  external `IDbConnection` was supplied (via `DapperServiceFactory.Create(IDbConnection)`), the
+  connection was returned as-is even if it was in `Closed` state. This caused `BeginTransaction`
+  and CRUD operations to throw `InvalidOperationException` because the connection was not open.
+  Now `GetOpenConnection()` and `GetOpenConnectionAsync()` open external connections that are
+  not yet open, without taking ownership of their lifetime (external connections are still not
+  closed or disposed by the service).
+
+### Added
+
+- **84 new unit tests** covering `IDapperService` and its implementation. Total test count is
+  now 157 (up from 73). New test files:
+  - `DapperServiceConstructorTests` — constructor validation, disposal semantics
+  - `DapperServiceTransactionTests` — TransactionCount, Begin/Commit/Rollback, savepoint
+    nesting, error conditions
+  - `DapperServiceCrudTests` — Insert/Update/Delete/GetById with SQL assertion via spy
+    connection, composite key handling, attach/detach change tracking
+  - `DapperSpyCompatibilityTests` — verifies that Dapper works with the spy IDbConnection
+  - `QueryCacheTests` — SQL generation for Insert/Update/Delete/GetById, primary key and
+    identity property resolution, column name mapping, identifier sanitisation
+  - `StoredProcedureExecutorValidationTests` — input validation for stored procedure, scalar
+    function and table function name arguments (theory-based with 25 cases)
+- **SpyDbConnection** — a test-only `IDbConnection` implementation that records all executed
+  commands without contacting a real database. Allows tests to assert on the exact SQL text and
+  parameters that Dapper would have sent.
+- **ListDataReader<T>** — a test-only `IDataReader` implementation that wraps a list of
+  objects, useful for tests that need to simulate result sets returned by the database.
+
 ## [4.8.1] - 2026-06-19
 
 ### Changed

--- a/EasyDapper.Tests/DapperService/DapperServiceConstructorTests.cs
+++ b/EasyDapper.Tests/DapperService/DapperServiceConstructorTests.cs
@@ -1,0 +1,85 @@
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Linq;
+using Xunit;
+
+namespace EasyDapper.Tests.DapperService
+{
+    public class DapperServiceConstructorTests
+    {
+        [Fact]
+        public void Constructor_NullConnectionString_Throws()
+        {
+            Assert.Throws<ArgumentNullException>(() => new global::EasyDapper.DapperService((string)null));
+        }
+
+        [Fact]
+        public void Constructor_EmptyConnectionString_Throws()
+        {
+            Assert.Throws<ArgumentNullException>(() => new global::EasyDapper.DapperService(""));
+        }
+
+        [Fact]
+        public void Constructor_WhitespaceConnectionString_Throws()
+        {
+            Assert.Throws<ArgumentNullException>(() => new global::EasyDapper.DapperService("   "));
+        }
+
+        [Fact]
+        public void Constructor_NullExternalConnection_Throws()
+        {
+            Assert.Throws<ArgumentNullException>(() => new global::EasyDapper.DapperService((System.Data.IDbConnection)null));
+        }
+
+        [Fact]
+        public void Constructor_WithConnectionString_InitializesService()
+        {
+            using (var svc = new global::EasyDapper.DapperService("Server=localhost;Database=Test;Integrated Security=true"))
+            {
+                Assert.NotNull(svc);
+                Assert.Equal(0, svc.TransactionCount());
+            }
+        }
+
+        [Fact]
+        public void Constructor_WithExternalConnection_DoesNotOpenConnection()
+        {
+            var spy = new SpyDbConnection();
+            using (var svc = new global::EasyDapper.DapperService(spy))
+            {
+                Assert.False(spy.WasOpened, "Constructor must not open external connection");
+                Assert.Equal(ConnectionState.Closed, spy.State);
+            }
+        }
+
+        [Fact]
+        public void Constructor_ConnectionString_DoesNotOpenConnection()
+        {
+            using (var svc = new global::EasyDapper.DapperService("Server=localhost;Database=Test;Integrated Security=true;Connect Timeout=1"))
+            {
+                Assert.Equal(0, svc.TransactionCount());
+            }
+        }
+
+        [Fact]
+        public void Dispose_CanBeCalledMultipleTimes()
+        {
+            var spy = new SpyDbConnection();
+            var svc = new global::EasyDapper.DapperService(spy);
+            svc.Dispose();
+            svc.Dispose();
+            svc.Dispose();
+        }
+
+        [Fact]
+        public void Dispose_DoesNotCloseExternalConnection()
+        {
+            var spy = new SpyDbConnection();
+            spy.Open();
+            var svc = new global::EasyDapper.DapperService(spy);
+            svc.Dispose();
+            Assert.Equal(ConnectionState.Open, spy.State);
+        }
+    }
+}

--- a/EasyDapper.Tests/DapperService/DapperServiceCrudTests.cs
+++ b/EasyDapper.Tests/DapperService/DapperServiceCrudTests.cs
@@ -1,0 +1,318 @@
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Linq;
+using Xunit;
+
+namespace EasyDapper.Tests.DapperService
+{
+    public class DapperServiceCrudTests
+    {
+        [Fact]
+        public void Insert_NullEntity_Throws()
+        {
+            using (var svc = new global::EasyDapper.DapperService(new SpyDbConnection()))
+            {
+                Assert.Throws<ArgumentNullException>(() => svc.Insert<Person>(null));
+            }
+        }
+
+        [Fact]
+        public void Insert_WithIdentity_ExecutesInsertWithScopeIdentity()
+        {
+            var spy = new SpyDbConnection();
+            spy.Open();
+            spy.NextExecuteScalarResult = 42;
+
+            using (var svc = new global::EasyDapper.DapperService(spy))
+            {
+                var person = new Person { Name = "Alice", Age = 30 };
+                var result = svc.Insert(person);
+
+                Assert.Equal(1, result);
+                Assert.Equal(42, person.Id);
+                Assert.Equal(1, spy.ExecutedCommands.Count);
+
+                var sql = spy.LastCommandText;
+                Assert.Contains("INSERT INTO [dbo].[Person]", sql);
+                Assert.Contains("SELECT CAST(SCOPE_IDENTITY() AS INT)", sql);
+            }
+        }
+
+        [Fact]
+        public void Insert_WithoutIdentity_ExecutesPlainInsert()
+        {
+            var spy = new SpyDbConnection();
+            spy.Open();
+            spy.NextExecuteNonQueryResult = 1;
+
+            using (var svc = new global::EasyDapper.DapperService(spy))
+            {
+                var entity = new CompositeEntity { Key1 = 1, Key2 = "A", Data = "test" };
+                var result = svc.Insert(entity);
+
+                Assert.Equal(1, result);
+                var sql = spy.LastCommandText;
+                Assert.Contains("INSERT INTO [dbo].[CompositeEntity]", sql);
+                Assert.DoesNotContain("SCOPE_IDENTITY", sql);
+            }
+        }
+
+        [Fact]
+        public void Update_NullEntity_Throws()
+        {
+            using (var svc = new global::EasyDapper.DapperService(new SpyDbConnection()))
+            {
+                Assert.Throws<ArgumentNullException>(() => svc.Update<Person>(null));
+            }
+        }
+
+        [Fact]
+        public void Update_NotAttached_PerformsFullUpdate()
+        {
+            var spy = new SpyDbConnection();
+            spy.Open();
+            spy.NextExecuteNonQueryResult = 1;
+
+            using (var svc = new global::EasyDapper.DapperService(spy))
+            {
+                var person = new Person { Id = 5, Name = "Bob", Age = 25 };
+                var result = svc.Update(person);
+
+                Assert.Equal(1, result);
+                var sql = spy.LastCommandText;
+                Assert.Contains("UPDATE [dbo].[Person]", sql);
+                Assert.Contains("SET", sql);
+                Assert.Contains("[CurrentFirstName] = @Name", sql);
+                Assert.Contains("[Age] = @Age", sql);
+                Assert.Contains("WHERE [Id] = @Id", sql);
+            }
+        }
+
+        [Fact]
+        public void Update_Attached_WithChanges_PerformsDynamicUpdate()
+        {
+            var spy = new SpyDbConnection();
+            spy.Open();
+            spy.NextExecuteNonQueryResult = 1;
+
+            using (var svc = new global::EasyDapper.DapperService(spy))
+            {
+                var person = new Person { Id = 5, Name = "Bob", Age = 25 };
+                svc.Attach(person);
+
+                person.Age = 26;
+
+                var result = svc.Update(person);
+
+                Assert.Equal(1, result);
+                var sql = spy.LastCommandText;
+                Assert.Contains("UPDATE [dbo].[Person] SET", sql);
+                Assert.Contains("[Age] = @Age", sql);
+                Assert.DoesNotContain("[CurrentFirstName] = @Name", sql);
+                Assert.Contains("WHERE [Id] = @pk_Id", sql);
+            }
+        }
+
+        [Fact]
+        public void Update_Attached_WithNoChanges_ReturnsZero()
+        {
+            var spy = new SpyDbConnection();
+            spy.Open();
+
+            using (var svc = new global::EasyDapper.DapperService(spy))
+            {
+                var person = new Person { Id = 5, Name = "Bob", Age = 25 };
+                svc.Attach(person);
+
+                var result = svc.Update(person);
+
+                Assert.Equal(0, result);
+                Assert.Equal(0, spy.ExecutedCommands.Count);
+            }
+        }
+
+        [Fact]
+        public void Delete_NullEntity_Throws()
+        {
+            using (var svc = new global::EasyDapper.DapperService(new SpyDbConnection()))
+            {
+                Assert.Throws<ArgumentNullException>(() => svc.Delete<Person>(null));
+            }
+        }
+
+        [Fact]
+        public void Delete_ExecutesDeleteWithPrimaryKey()
+        {
+            var spy = new SpyDbConnection();
+            spy.Open();
+            spy.NextExecuteNonQueryResult = 1;
+
+            using (var svc = new global::EasyDapper.DapperService(spy))
+            {
+                var person = new Person { Id = 5, Name = "Bob", Age = 25 };
+                var result = svc.Delete(person);
+
+                Assert.Equal(1, result);
+                var sql = spy.LastCommandText;
+                Assert.Contains("DELETE FROM [dbo].[Person]", sql);
+                Assert.Contains("WHERE [Id] = @Id", sql);
+            }
+        }
+
+        [Fact]
+        public void Delete_CompositeKey_WhereClauseIncludesBothKeys()
+        {
+            var spy = new SpyDbConnection();
+            spy.Open();
+            spy.NextExecuteNonQueryResult = 1;
+
+            using (var svc = new global::EasyDapper.DapperService(spy))
+            {
+                var entity = new CompositeEntity { Key1 = 7, Key2 = "X" };
+                var result = svc.Delete(entity);
+
+                Assert.Equal(1, result);
+                var sql = spy.LastCommandText;
+                Assert.Contains("DELETE FROM [dbo].[CompositeEntity]", sql);
+                Assert.Contains("[Key1] = @Key1", sql);
+                Assert.Contains("[Key2] = @Key2", sql);
+            }
+        }
+
+        [Fact]
+        public void GetById_SingleKey_ExecutesSelectWithIdParameter()
+        {
+            var spy = new SpyDbConnection();
+            spy.Open();
+
+            using (var svc = new global::EasyDapper.DapperService(spy))
+            {
+                var result = svc.GetById<Person>(5);
+
+                Assert.Null(result);
+                var sql = spy.LastCommandText;
+                Assert.Contains("SELECT", sql);
+                Assert.Contains("FROM [dbo].[Person]", sql);
+                Assert.Contains("WHERE [Id] = @Id", sql);
+            }
+        }
+
+        [Fact]
+        public void GetById_NullId_Throws()
+        {
+            using (var svc = new global::EasyDapper.DapperService(new SpyDbConnection()))
+            {
+                Assert.Throws<ArgumentNullException>(() => svc.GetById<Person>((object)null));
+            }
+        }
+
+        [Fact]
+        public void GetById_CompositeKey_WithMatchingAnonymousObject_ExecutesSelectWithBothKeys()
+        {
+            var spy = new SpyDbConnection();
+            spy.Open();
+
+            using (var svc = new global::EasyDapper.DapperService(spy))
+            {
+                var result = svc.GetById<CompositeEntity>(new { Key1 = 1, Key2 = "A" });
+
+                Assert.Null(result);
+                var sql = spy.LastCommandText;
+                Assert.Contains("WHERE [Key1] = @Key1", sql);
+                Assert.Contains("[Key2] = @Key2", sql);
+            }
+        }
+
+        [Fact]
+        public void GetById_CompositeKey_WithEntityInstance_ExecutesSelectWithBothKeys()
+        {
+            var spy = new SpyDbConnection();
+            spy.Open();
+
+            using (var svc = new global::EasyDapper.DapperService(spy))
+            {
+                var probe = new CompositeEntity { Key1 = 1, Key2 = "A" };
+                var result = svc.GetById(probe);
+
+                Assert.Null(result);
+                var sql = spy.LastCommandText;
+                Assert.Contains("WHERE [Key1] = @Key1", sql);
+                Assert.Contains("[Key2] = @Key2", sql);
+            }
+        }
+
+        [Fact]
+        public void GetById_CompositeKey_WithScalarId_Throws()
+        {
+            using (var svc = new global::EasyDapper.DapperService(new SpyDbConnection()))
+            {
+                Assert.Throws<ArgumentException>(() => svc.GetById<CompositeEntity>(123));
+            }
+        }
+
+        [Fact]
+        public void GetById_CompositeKey_WithMismatchedAnonymousObject_Throws()
+        {
+            using (var svc = new global::EasyDapper.DapperService(new SpyDbConnection()))
+            {
+                Assert.Throws<ArgumentException>(() => svc.GetById<CompositeEntity>(new { WrongName = 1 }));
+            }
+        }
+
+        [Fact]
+        public void DeleteList_NullEntities_Throws()
+        {
+            using (var svc = new global::EasyDapper.DapperService(new SpyDbConnection()))
+            {
+                Assert.Throws<ArgumentNullException>(() => svc.DeleteList<Person>(null));
+            }
+        }
+
+        [Fact]
+        public void DeleteList_ExecutesOneDeletePerEntity()
+        {
+            var spy = new SpyDbConnection();
+            spy.Open();
+            spy.NextExecuteNonQueryResult = 1;
+
+            using (var svc = new global::EasyDapper.DapperService(spy))
+            {
+                var entities = new[]
+                {
+                    new Person { Id = 1, Name = "A", Age = 1 },
+                    new Person { Id = 2, Name = "B", Age = 2 },
+                    new Person { Id = 3, Name = "C", Age = 3 }
+                };
+                var result = svc.DeleteList(entities);
+
+                Assert.Equal(3, result);
+                Assert.Equal(3, spy.ExecutedCommands.Count);
+                Assert.All(spy.ExecutedCommands, c => Assert.Contains("DELETE FROM", c.CommandText));
+            }
+        }
+
+        [Fact]
+        public void InsertList_EmptyList_ReturnsZero()
+        {
+            var spy = new SpyDbConnection();
+            spy.Open();
+
+            using (var svc = new global::EasyDapper.DapperService(spy))
+            {
+                var result = svc.InsertList(new Person[0]);
+                Assert.Equal(0, result);
+                Assert.Equal(0, spy.ExecutedCommands.Count);
+            }
+        }
+
+        [Fact]
+        public void InsertList_NullEntities_Throws()
+        {
+            using (var svc = new global::EasyDapper.DapperService(new SpyDbConnection()))
+            {
+                Assert.Throws<ArgumentNullException>(() => svc.InsertList<Person>(null));
+            }
+        }
+    }
+}

--- a/EasyDapper.Tests/DapperService/DapperServiceTransactionTests.cs
+++ b/EasyDapper.Tests/DapperService/DapperServiceTransactionTests.cs
@@ -1,0 +1,134 @@
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Linq;
+using Xunit;
+
+namespace EasyDapper.Tests.DapperService
+{
+    public class DapperServiceTransactionTests
+    {
+        private global::EasyDapper.DapperService CreateService()
+            => new global::EasyDapper.DapperService(new SpyDbConnection());
+
+        [Fact]
+        public void TransactionCount_InitiallyZero()
+        {
+            using (var svc = CreateService())
+            {
+                Assert.Equal(0, svc.TransactionCount());
+            }
+        }
+
+        [Fact]
+        public void BeginTransaction_IncrementsCountToOne()
+        {
+            using (var svc = CreateService())
+            {
+                svc.BeginTransaction();
+                Assert.Equal(1, svc.TransactionCount());
+            }
+        }
+
+        [Fact]
+        public void MultipleBeginTransactions_IncrementCountToN()
+        {
+            using (var svc = CreateService())
+            {
+                svc.BeginTransaction();
+                svc.BeginTransaction();
+                svc.BeginTransaction();
+                Assert.Equal(3, svc.TransactionCount());
+            }
+        }
+
+        [Fact]
+        public void CommitTransaction_DecrementsCount()
+        {
+            using (var svc = CreateService())
+            {
+                svc.BeginTransaction();
+                svc.BeginTransaction();
+                svc.BeginTransaction();
+                Assert.Equal(3, svc.TransactionCount());
+
+                svc.CommitTransaction();
+                Assert.Equal(2, svc.TransactionCount());
+
+                svc.CommitTransaction();
+                Assert.Equal(1, svc.TransactionCount());
+
+                svc.CommitTransaction();
+                Assert.Equal(0, svc.TransactionCount());
+            }
+        }
+
+        [Fact]
+        public void RollbackTransaction_DecrementsCount()
+        {
+            using (var svc = CreateService())
+            {
+                svc.BeginTransaction();
+                svc.BeginTransaction();
+                svc.BeginTransaction();
+
+                svc.RollbackTransaction();
+                Assert.Equal(2, svc.TransactionCount());
+            }
+        }
+
+        [Fact]
+        public void CommitTransaction_WithoutBegin_Throws()
+        {
+            using (var svc = CreateService())
+            {
+                Assert.Throws<InvalidOperationException>(() => svc.CommitTransaction());
+            }
+        }
+
+        [Fact]
+        public void RollbackTransaction_WithoutBegin_Throws()
+        {
+            using (var svc = CreateService())
+            {
+                Assert.Throws<InvalidOperationException>(() => svc.RollbackTransaction());
+            }
+        }
+
+        [Fact]
+        public void BeginTransaction_OpensConnection_WhenConnectionIsClosed()
+        {
+            var spy = new SpyDbConnection();
+            using (var svc = new global::EasyDapper.DapperService(spy))
+            {
+                svc.BeginTransaction();
+                Assert.True(spy.WasOpened);
+                Assert.Equal(ConnectionState.Open, spy.State);
+            }
+        }
+
+        [Fact]
+        public void BeginTransaction_WithPreOpenedExternalConnection_DoesNotReopen()
+        {
+            var spy = new SpyDbConnection();
+            spy.Open();
+            using (var svc = new global::EasyDapper.DapperService(spy))
+            {
+                svc.BeginTransaction();
+                Assert.True(spy.WasOpened);
+                Assert.Equal(ConnectionState.Open, spy.State);
+            }
+        }
+
+        [Fact]
+        public void Dispose_WithActiveTransaction_RollsBack()
+        {
+            var spy = new SpyDbConnection();
+            spy.Open();
+            using (var svc = new global::EasyDapper.DapperService(spy))
+            {
+                svc.BeginTransaction();
+            }
+        }
+    }
+}

--- a/EasyDapper.Tests/DapperService/DapperSpyCompatibilityTests.cs
+++ b/EasyDapper.Tests/DapperService/DapperSpyCompatibilityTests.cs
@@ -1,0 +1,42 @@
+using System.Linq;
+using Dapper;
+using Xunit;
+
+namespace EasyDapper.Tests.DapperService
+{
+    public class DapperSpyCompatibilityTests
+    {
+        [Fact]
+        public void Dapper_Execute_Calls_Connection_CreateCommand()
+        {
+            var spy = new SpyDbConnection();
+            spy.Open();
+            spy.NextExecuteNonQueryResult = 42;
+            var result = spy.Execute("INSERT INTO Foo (Bar) VALUES (@Bar)", new { Bar = "baz" });
+            Assert.Equal(42, result);
+            Assert.Equal(1, spy.ExecutedCommands.Count);
+            Assert.Contains("INSERT INTO Foo", spy.LastCommandText);
+        }
+
+        [Fact]
+        public void Dapper_ExecuteScalar_Calls_Connection_CreateCommand()
+        {
+            var spy = new SpyDbConnection();
+            spy.Open();
+            spy.NextExecuteScalarResult = 99;
+            var result = spy.ExecuteScalar<int>("SELECT COUNT(*) FROM Foo");
+            Assert.Equal(99, result);
+            Assert.Equal(1, spy.ExecutedCommands.Count);
+        }
+
+        [Fact]
+        public void Dapper_QueryFirstOrDefault_WithEmptyReader_ReturnsDefault()
+        {
+            var spy = new SpyDbConnection();
+            spy.Open();
+            var result = spy.QueryFirstOrDefault<Person>("SELECT * FROM Person WHERE Id = @Id", new { Id = 1 });
+            Assert.Null(result);
+            Assert.Equal(1, spy.ExecutedCommands.Count);
+        }
+    }
+}

--- a/EasyDapper.Tests/ListDataReader.cs
+++ b/EasyDapper.Tests/ListDataReader.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Collections.Generic;
+using System.Data;
+
+namespace EasyDapper.Tests
+{
+    public sealed class ListDataReader<T> : IDataReader
+    {
+        private readonly IList<T> _rows;
+        private readonly Func<T, object[]> _rowToArray;
+        private readonly string[] _columnNames;
+        private int _position = -1;
+
+        public ListDataReader(IList<T> rows, string[] columnNames, Func<T, object[]> rowToArray)
+        {
+            _rows = rows;
+            _columnNames = columnNames;
+            _rowToArray = rowToArray;
+        }
+
+        public int FieldCount => _columnNames.Length;
+        public object this[int i] => _rowToArray(_rows[_position])[i];
+        public object this[string name] => _rowToArray(_rows[_position])[Array.IndexOf(_columnNames, name)];
+
+        public int Depth => 0;
+        public bool IsClosed => false;
+        public int RecordsAffected => _rows.Count;
+
+        public bool Read()
+        {
+            if (_position < _rows.Count - 1) { _position++; return true; }
+            return false;
+        }
+
+        public bool NextResult() => false;
+        public void Close() { }
+        public void Dispose() { }
+        public DataTable GetSchemaTable() => null;
+
+        public string GetName(int i) => _columnNames[i];
+        public int GetOrdinal(string name) => Array.IndexOf(_columnNames, name);
+        public Type GetFieldType(int i) => typeof(object);
+        public string GetDataTypeName(int i) => "object";
+        public object GetValue(int i) => this[i];
+        public int GetValues(object[] values)
+        {
+            var arr = _rowToArray(_rows[_position]);
+            for (int i = 0; i < arr.Length && i < values.Length; i++) values[i] = arr[i];
+            return arr.Length;
+        }
+        public bool IsDBNull(int i) => this[i] == null || this[i] == DBNull.Value;
+
+        public bool GetBoolean(int i) => Convert.ToBoolean(this[i]);
+        public byte GetByte(int i) => Convert.ToByte(this[i]);
+        public char GetChar(int i) => Convert.ToChar(this[i]);
+        public DateTime GetDateTime(int i) => Convert.ToDateTime(this[i]);
+        public decimal GetDecimal(int i) => Convert.ToDecimal(this[i]);
+        public double GetDouble(int i) => Convert.ToDouble(this[i]);
+        public float GetFloat(int i) => Convert.ToSingle(this[i]);
+        public Guid GetGuid(int i) => (Guid)this[i];
+        public short GetInt16(int i) => Convert.ToInt16(this[i]);
+        public int GetInt32(int i) => Convert.ToInt32(this[i]);
+        public long GetInt64(int i) => Convert.ToInt64(this[i]);
+        public string GetString(int i) => (string)this[i];
+
+        public long GetBytes(int i, long fieldOffset, byte[] buffer, int bufferoffset, int length) => 0;
+        public long GetChars(int i, long fieldoffset, char[] buffer, int bufferoffset, int length) => 0;
+        public IDataReader GetData(int i) => null;
+    }
+}

--- a/EasyDapper.Tests/QueryCache/QueryCacheTests.cs
+++ b/EasyDapper.Tests/QueryCache/QueryCacheTests.cs
@@ -1,0 +1,188 @@
+using System;
+using System.Linq;
+using EasyDapper.Attributes;
+using Xunit;
+
+namespace EasyDapper.Tests.QueryCache
+{
+    public class QueryCacheTests
+    {
+        private global::EasyDapper.QueryCache CreateCache()
+            => new global::EasyDapper.QueryCache();
+
+        [Fact]
+        public void GetTableName_WithTableAttribute_ReturnsBracketedSchemaAndTable()
+        {
+            var cache = CreateCache();
+            var name = cache.GetTableName<Person>();
+            Assert.Equal("[dbo].[Person]", name);
+        }
+
+        [Fact]
+        public void GetTableName_WithCustomSchema_ReturnsBracketedSchemaAndTable()
+        {
+            var cache = CreateCache();
+            var name = cache.GetTableName<Order>();
+            Assert.Equal("[dbo].[Order]", name);
+        }
+
+        [Fact]
+        public void GetTableName_CalledTwice_ReturnsSameInstance()
+        {
+            var cache = CreateCache();
+            var name1 = cache.GetTableName<Person>();
+            var name2 = cache.GetTableName<Person>();
+            Assert.Same(name1, name2);
+        }
+
+        [Fact]
+        public void GetInsertQuery_WithIdentity_ReturnsInsertWithScopeIdentity()
+        {
+            var cache = CreateCache();
+            var query = cache.GetInsertQuery<Person>();
+            Assert.Contains("INSERT INTO [dbo].[Person]", query);
+            Assert.Contains("VALUES", query);
+            Assert.Contains("SELECT CAST(SCOPE_IDENTITY() AS INT)", query);
+            Assert.DoesNotContain("[Id]", query.Split(new[] { "VALUES" }, StringSplitOptions.None)[0]);
+        }
+
+        [Fact]
+        public void GetInsertQuery_WithoutIdentity_ReturnsPlainInsert()
+        {
+            var cache = CreateCache();
+            var query = cache.GetInsertQuery<CompositeEntity>();
+            Assert.Contains("INSERT INTO [dbo].[CompositeEntity]", query);
+            Assert.DoesNotContain("SCOPE_IDENTITY", query);
+        }
+
+        [Fact]
+        public void GetUpdateQuery_WithRegularEntity_GeneratesSetAndWhere()
+        {
+            var cache = CreateCache();
+            var query = cache.GetUpdateQuery<Person>();
+            Assert.Contains("UPDATE [dbo].[Person]", query);
+            Assert.Contains("SET", query);
+            Assert.Contains("[CurrentFirstName] = @Name", query);
+            Assert.Contains("[Age] = @Age", query);
+            Assert.Contains("WHERE [Id] = @Id", query);
+        }
+
+        [Fact]
+        public void GetDeleteQuery_WithSingleKey_GeneratesWhereWithKey()
+        {
+            var cache = CreateCache();
+            var query = cache.GetDeleteQuery<Person>();
+            Assert.Contains("DELETE FROM [dbo].[Person]", query);
+            Assert.Contains("WHERE [Id] = @Id", query);
+        }
+
+        [Fact]
+        public void GetDeleteQuery_WithCompositeKey_GeneratesWhereWithAllKeys()
+        {
+            var cache = CreateCache();
+            var query = cache.GetDeleteQuery<CompositeEntity>();
+            Assert.Contains("DELETE FROM [dbo].[CompositeEntity]", query);
+            Assert.Contains("[Key1] = @Key1", query);
+            Assert.Contains("[Key2] = @Key2", query);
+        }
+
+        [Fact]
+        public void GetGetByIdQuery_WithSingleKey_UsesAtIdParameter()
+        {
+            var cache = CreateCache();
+            var query = cache.GetGetByIdQuery<Person>();
+            Assert.Contains("SELECT", query);
+            Assert.Contains("FROM [dbo].[Person]", query);
+            Assert.Contains("WHERE [Id] = @Id", query);
+        }
+
+        [Fact]
+        public void GetGetByIdQuery_WithCompositeKey_UsesNamedParameters()
+        {
+            var cache = CreateCache();
+            var query = cache.GetGetByIdQuery<CompositeEntity>();
+            Assert.Contains("WHERE [Key1] = @Key1", query);
+            Assert.Contains("[Key2] = @Key2", query);
+        }
+
+        [Fact]
+        public void GetPrimaryKeyProperties_WithSingleKey_ReturnsOneProperty()
+        {
+            var cache = CreateCache();
+            var pks = cache.GetPrimaryKeyProperties<Person>();
+            Assert.Equal(1, pks.Count);
+            Assert.Equal("Id", pks[0].Name);
+        }
+
+        [Fact]
+        public void GetPrimaryKeyProperties_WithCompositeKey_ReturnsAllKeys()
+        {
+            var cache = CreateCache();
+            var pks = cache.GetPrimaryKeyProperties<CompositeEntity>();
+            Assert.Equal(2, pks.Count);
+            Assert.Contains(pks, p => p.Name == "Key1");
+            Assert.Contains(pks, p => p.Name == "Key2");
+        }
+
+        [Fact]
+        public void GetPrimaryKeyProperties_NoPrimaryKey_Throws()
+        {
+            var cache = CreateCache();
+            Assert.Throws<InvalidOperationException>(() => cache.GetPrimaryKeyProperties<NoKeyEntity>());
+        }
+
+        [Fact]
+        public void GetIdentityProperty_WithIdentity_ReturnsProperty()
+        {
+            var cache = CreateCache();
+            var identity = cache.GetIdentityProperty<Person>();
+            Assert.NotNull(identity);
+            Assert.Equal("Id", identity.Name);
+        }
+
+        [Fact]
+        public void GetIdentityProperty_WithoutIdentity_ReturnsNull()
+        {
+            var cache = CreateCache();
+            var identity = cache.GetIdentityProperty<CompositeEntity>();
+            Assert.Null(identity);
+        }
+
+        [Fact]
+        public void GetColumnName_WithColumnAttribute_ReturnsAttributeColumnName()
+        {
+            var cache = CreateCache();
+            var prop = typeof(Person).GetProperty("Name");
+            var name = cache.GetColumnName(prop);
+            Assert.Equal("[CurrentFirstName]", name);
+        }
+
+        [Fact]
+        public void GetColumnName_WithoutColumnAttribute_ReturnsPropertyName()
+        {
+            var cache = CreateCache();
+            var prop = typeof(Person).GetProperty("Age");
+            var name = cache.GetColumnName(prop);
+            Assert.Equal("[Age]", name);
+        }
+
+        [Fact]
+        public void GetTableName_InvalidIdentifier_Throws()
+        {
+            var cache = CreateCache();
+            Assert.ThrowsAny<Exception>(() => cache.GetTableName<BadNameEntity>());
+        }
+    }
+
+    public class NoKeyEntity
+    {
+        public string Name { get; set; }
+    }
+
+    [Table("Bad-Name", "dbo")]
+    public class BadNameEntity
+    {
+        [PrimaryKey]
+        public int Id { get; set; }
+    }
+}

--- a/EasyDapper.Tests/SpyDbConnection.cs
+++ b/EasyDapper.Tests/SpyDbConnection.cs
@@ -1,0 +1,195 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Data;
+using System.Linq;
+
+namespace EasyDapper.Tests
+{
+    public sealed class SpyDbConnection : IDbConnection
+    {
+        public sealed class SpyDbCommand : IDbCommand
+        {
+            private readonly SpyDbConnection _owner;
+            public SpyDbCommand(SpyDbConnection owner) { _owner = owner; }
+            public string CommandText { get; set; }
+            public int CommandTimeout { get; set; }
+            public CommandType CommandType { get; set; }
+            public IDbConnection Connection { get; set; }
+            public IDbTransaction Transaction { get; set; }
+            public UpdateRowSource UpdatedRowSource { get; set; }
+            private readonly List<IDbDataParameter> _parameters = new List<IDbDataParameter>();
+            public IDataParameterCollection Parameters => new SpyParameterCollection(_parameters);
+
+            public void Cancel() { }
+            public IDbDataParameter CreateParameter() => new SpyDbDataParameter();
+            public int ExecuteNonQuery()
+            {
+                _owner.ExecutedCommands.Add(this);
+                return _owner.NextExecuteNonQueryResult;
+            }
+            public IDataReader ExecuteReader() => ExecuteReader(CommandBehavior.Default);
+            public IDataReader ExecuteReader(CommandBehavior behavior)
+            {
+                _owner.ExecutedCommands.Add(this);
+                return _owner.NextDataReader ?? new EmptyDataReader();
+            }
+            public object ExecuteScalar()
+            {
+                _owner.ExecutedCommands.Add(this);
+                return _owner.NextExecuteScalarResult;
+            }
+            public void Prepare() { }
+            public void Dispose() { }
+
+            public IDictionary<string, object> GetParameterSnapshot()
+            {
+                var dict = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
+                foreach (var p in _parameters)
+                {
+                    if (!string.IsNullOrEmpty(p.ParameterName)) dict[p.ParameterName] = p.Value;
+                }
+                return dict;
+            }
+        }
+
+        private sealed class SpyDbDataParameter : IDbDataParameter
+        {
+            public DbType DbType { get; set; }
+            public ParameterDirection Direction { get; set; }
+            public bool IsNullable { get; set; }
+            public string ParameterName { get; set; }
+            public int Size { get; set; }
+            public string SourceColumn { get; set; }
+            public DataRowVersion SourceVersion { get; set; }
+            public object Value { get; set; }
+            public byte Precision { get; set; }
+            public byte Scale { get; set; }
+        }
+
+        private sealed class SpyParameterCollection : IDataParameterCollection
+        {
+            private readonly List<IDbDataParameter> _parameters;
+            public SpyParameterCollection(List<IDbDataParameter> parameters) { _parameters = parameters; }
+            public int Add(object value) { _parameters.Add((IDbDataParameter)value); return _parameters.Count - 1; }
+            public void Clear() { _parameters.Clear(); }
+            public bool Contains(object value) => _parameters.Contains(value);
+            public bool Contains(string parameterName) => _parameters.Any(p => string.Equals(p.ParameterName, parameterName, StringComparison.OrdinalIgnoreCase));
+            public int IndexOf(object value) => _parameters.IndexOf((IDbDataParameter)value);
+            public int IndexOf(string parameterName) => _parameters.FindIndex(p => string.Equals(p.ParameterName, parameterName, StringComparison.OrdinalIgnoreCase));
+            public void Insert(int index, object value) { _parameters.Insert(index, (IDbDataParameter)value); }
+            public void Remove(object value) { _parameters.Remove((IDbDataParameter)value); }
+            public void RemoveAt(int index) { _parameters.RemoveAt(index); }
+            public void RemoveAt(string parameterName) { _parameters.RemoveAll(p => string.Equals(p.ParameterName, parameterName, StringComparison.OrdinalIgnoreCase)); }
+            public object this[int index]
+            {
+                get { return _parameters[index]; }
+                set { _parameters[index] = (IDbDataParameter)value; }
+            }
+            public object this[string parameterName]
+            {
+                get
+                {
+                    var idx = IndexOf(parameterName);
+                    return idx >= 0 ? _parameters[idx] : null;
+                }
+                set
+                {
+                    _parameters.RemoveAll(p => string.Equals(p.ParameterName, parameterName, StringComparison.OrdinalIgnoreCase));
+                    var typed = value as IDbDataParameter;
+                    if (typed != null) _parameters.Add(typed);
+                }
+            }
+            public bool IsReadOnly => false;
+            public bool IsFixedSize => false;
+            public bool IsSynchronized => false;
+            public object SyncRoot => this;
+            public int Count => _parameters.Count;
+            public void CopyTo(Array array, int index) { ((ICollection)_parameters).CopyTo(array, index); }
+            IEnumerator IEnumerable.GetEnumerator() => _parameters.GetEnumerator();
+        }
+
+        private sealed class EmptyDataReader : IDataReader
+        {
+            public int Depth => 0;
+            public bool IsClosed => true;
+            public int RecordsAffected => 0;
+            public int FieldCount => 0;
+            public object this[int i] => null;
+            public object this[string name] => null;
+            public void Close() { }
+            public void Dispose() { }
+            public bool GetBoolean(int i) => false;
+            public byte GetByte(int i) => 0;
+            public long GetBytes(int i, long fieldOffset, byte[] buffer, int bufferoffset, int length) => 0;
+            public char GetChar(int i) => '\0';
+            public long GetChars(int i, long fieldoffset, char[] buffer, int bufferoffset, int length) => 0;
+            public IDataReader GetData(int i) => null;
+            public string GetDataTypeName(int i) => null;
+            public DateTime GetDateTime(int i) => default(DateTime);
+            public decimal GetDecimal(int i) => 0;
+            public double GetDouble(int i) => 0;
+            public Type GetFieldType(int i) => typeof(object);
+            public float GetFloat(int i) => 0;
+            public Guid GetGuid(int i) => Guid.Empty;
+            public short GetInt16(int i) => 0;
+            public int GetInt32(int i) => 0;
+            public long GetInt64(int i) => 0;
+            public string GetName(int i) => null;
+            public int GetOrdinal(string name) => -1;
+            public string GetString(int i) => null;
+            public object GetValue(int i) => null;
+            public int GetValues(object[] values) => 0;
+            public bool IsDBNull(int i) => true;
+            public bool NextResult() => false;
+            public bool Read() => false;
+            public DataTable GetSchemaTable() => null;
+        }
+
+        public string ConnectionString { get; set; }
+        public int ConnectionTimeout => 30;
+        public string Database => "Spy";
+        public ConnectionState State { get; private set; } = ConnectionState.Closed;
+        public bool WasOpened { get; private set; }
+
+        public List<SpyDbCommand> ExecutedCommands { get; } = new List<SpyDbCommand>();
+        public int NextExecuteNonQueryResult { get; set; } = 1;
+        public object NextExecuteScalarResult { get; set; } = 1;
+        public IDataReader NextDataReader { get; set; }
+
+        public IDbTransaction BeginTransaction() => new SpyDbTransaction(this);
+        public IDbTransaction BeginTransaction(IsolationLevel il) => new SpyDbTransaction(this);
+        public void ChangeDatabase(string databaseName) { }
+        public void Close() => State = ConnectionState.Closed;
+        public IDbCommand CreateCommand() => new SpyDbCommand(this);
+        public void Open()
+        {
+            WasOpened = true;
+            State = ConnectionState.Open;
+        }
+        public void Dispose() => State = ConnectionState.Closed;
+
+        public string LastCommandText => ExecutedCommands.Count > 0 ? ExecutedCommands[ExecutedCommands.Count - 1].CommandText : null;
+
+        public SpyDbCommand LastCommand => ExecutedCommands.Count > 0 ? ExecutedCommands[ExecutedCommands.Count - 1] : null;
+
+        public void Reset()
+        {
+            ExecutedCommands.Clear();
+            NextExecuteNonQueryResult = 1;
+            NextExecuteScalarResult = 1;
+            NextDataReader = null;
+        }
+    }
+
+    internal sealed class SpyDbTransaction : IDbTransaction
+    {
+        private readonly SpyDbConnection _connection;
+        public SpyDbTransaction(SpyDbConnection connection) { _connection = connection; }
+        public IDbConnection Connection => _connection;
+        public IsolationLevel IsolationLevel => IsolationLevel.ReadCommitted;
+        public void Commit() { }
+        public void Rollback() { }
+        public void Dispose() { }
+    }
+}

--- a/EasyDapper.Tests/StoredProcedure/StoredProcedureExecutorValidationTests.cs
+++ b/EasyDapper.Tests/StoredProcedure/StoredProcedureExecutorValidationTests.cs
@@ -1,0 +1,107 @@
+using System;
+using Xunit;
+
+namespace EasyDapper.Tests.StoredProcedure
+{
+    public class StoredProcedureExecutorValidationTests
+    {
+        private global::EasyDapper.StoredProcedureExecutor CreateExecutor()
+            => new global::EasyDapper.StoredProcedureExecutor(
+                new global::EasyDapper.ConnectionManager(new SpyDbConnection()),
+                new global::EasyDapper.SqlBuilder(new global::EasyDapper.QueryCache()));
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("   ")]
+        public void ExecuteStoredProcedure_NullOrEmptyName_Throws(string name)
+        {
+            var exec = CreateExecutor();
+            Assert.Throws<ArgumentException>(() => exec.ExecuteStoredProcedure<Person>(name));
+        }
+
+        [Theory]
+        [InlineData("usp; DROP TABLE")]
+        [InlineData("usp'--")]
+        [InlineData("usp EXEC")]
+        [InlineData("usp/*comment*/")]
+        [InlineData("usp name with space")]
+        public void ExecuteStoredProcedure_InvalidName_Throws(string name)
+        {
+            var exec = CreateExecutor();
+            Assert.Throws<ArgumentException>(() => exec.ExecuteStoredProcedure<Person>(name));
+        }
+
+        [Theory]
+        [InlineData("usp_GetUser")]
+        [InlineData("dbo.usp_GetUser")]
+        [InlineData("schema_name.procedure_name")]
+        [InlineData("Proc123")]
+        public void ExecuteStoredProcedure_ValidName_DoesNotThrowArgumentException(string name)
+        {
+            var spy = new SpyDbConnection();
+            spy.Open();
+            var exec = new global::EasyDapper.StoredProcedureExecutor(
+                new global::EasyDapper.ConnectionManager(spy),
+                new global::EasyDapper.SqlBuilder(new global::EasyDapper.QueryCache()));
+            var ex = Record.Exception(() => exec.ExecuteStoredProcedure<Person>(name));
+            Assert.False(ex is ArgumentException, $"Expected no ArgumentException but got: {ex?.GetType().Name}");
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public void ExecuteScalarFunction_NullOrEmptyName_Throws(string name)
+        {
+            var exec = CreateExecutor();
+            Assert.Throws<ArgumentException>(() => exec.ExecuteScalarFunction<int>(name));
+        }
+
+        [Theory]
+        [InlineData("fn; DROP TABLE")]
+        [InlineData("fn'--")]
+        public void ExecuteScalarFunction_InvalidName_Throws(string name)
+        {
+            var exec = CreateExecutor();
+            Assert.Throws<ArgumentException>(() => exec.ExecuteScalarFunction<int>(name));
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public void ExecuteTableFunction_NullOrEmptyName_Throws(string name)
+        {
+            var exec = CreateExecutor();
+            Assert.Throws<ArgumentException>(() => exec.ExecuteTableFunction<Person>(name, new { }));
+        }
+
+        [Theory]
+        [InlineData("fn; DROP TABLE")]
+        [InlineData("fn'--")]
+        public void ExecuteTableFunction_InvalidName_Throws(string name)
+        {
+            var exec = CreateExecutor();
+            Assert.Throws<ArgumentException>(() => exec.ExecuteTableFunction<Person>(name, new { }));
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public void ExecuteMultiResultStoredProcedure_NullOrEmptyName_Throws(string name)
+        {
+            var exec = CreateExecutor();
+            Assert.Throws<ArgumentException>(() => exec.ExecuteMultiResultStoredProcedure<Person>(
+                name, gr => null, new { }));
+        }
+
+        [Theory]
+        [InlineData("usp; DROP")]
+        [InlineData("usp'--")]
+        public void ExecuteMultiResultStoredProcedure_InvalidName_Throws(string name)
+        {
+            var exec = CreateExecutor();
+            Assert.Throws<ArgumentException>(() => exec.ExecuteMultiResultStoredProcedure<Person>(
+                name, gr => null, new { }));
+        }
+    }
+}

--- a/EasyDapper/EasyDapper.csproj
+++ b/EasyDapper/EasyDapper.csproj
@@ -3,17 +3,17 @@
         <PropertyGroup>
                 <TargetFrameworks>net45;netstandard2.0</TargetFrameworks>
                 <PackageId>SQLDapper.Easy</PackageId>
-                <PackageVersion>4.8.1</PackageVersion>
+                <PackageVersion>4.8.2</PackageVersion>
                 <Authors>Masoud Sarafraz</Authors>
                 <Description>A professional Dapper library with CRUD, dynamic queries, stored procedures, attributes, thread-safety, and transaction support.</Description>
                 <Title>Easy to use Dapper</Title>
                 <RepositoryUrl>https://github.com/MasoudSarafraz/EasyDapper.git</RepositoryUrl>
                 <PackageProjectUrl>https://github.com/MasoudSarafraz/EasyDapper.git</PackageProjectUrl>
-                <AssemblyVersion>4.8.1.0</AssemblyVersion>
-                <FileVersion>4.8.1.0</FileVersion>
+                <AssemblyVersion>4.8.2.0</AssemblyVersion>
+                <FileVersion>4.8.2.0</FileVersion>
                 <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
                 <PackageLicenseExpression>MIT</PackageLicenseExpression>
-                <Version>4.8.1</Version>
+                <Version>4.8.2</Version>
                 <PackageTags>dapper;sql;mssql</PackageTags>
                 <LangVersion>latest</LangVersion>
         </PropertyGroup>

--- a/EasyDapper/Transactions/ConnectionManager.cs
+++ b/EasyDapper/Transactions/ConnectionManager.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Data;
+using System.Data.Common;
 using System.Data.SqlClient;
 using System.Threading;
 using System.Threading.Tasks;
@@ -78,7 +79,11 @@ namespace EasyDapper
         {
             lock (_lock)
             {
-                if (_externalConnection != null) return _externalConnection;
+                if (_externalConnection != null)
+                {
+                    if (_externalConnection.State != ConnectionState.Open) _externalConnection.Open();
+                    return _externalConnection;
+                }
                 if (_connection == null) _connection = new SqlConnection(_connectionString);
                 EnsureConnectionOpen();
                 return _connection;
@@ -87,7 +92,16 @@ namespace EasyDapper
 
         public async Task<IDbConnection> GetOpenConnectionAsync()
         {
-            if (_externalConnection != null) return _externalConnection;
+            if (_externalConnection != null)
+            {
+                if (_externalConnection.State != ConnectionState.Open)
+                {
+                    var externalAsync = _externalConnection as DbConnection;
+                    if (externalAsync != null) await externalAsync.OpenAsync().ConfigureAwait(false);
+                    else _externalConnection.Open();
+                }
+                return _externalConnection;
+            }
 
             bool needOpen = false;
             SqlConnection localConn = null;
@@ -158,13 +172,12 @@ namespace EasyDapper
             lock (_lock)
             {
                 if (_transaction == null) throw new InvalidOperationException("No transaction is in progress");
-                try
+                if (_savePointStack.TryPop(out var savePointName))
                 {
-                    if (_savePointStack.TryPop(out var savePointName))
-                        ExecuteTransactionCommand($"ROLLBACK TRANSACTION {savePointName}");
-                    else
-                        _transaction.Rollback();
+                    ExecuteTransactionCommand($"ROLLBACK TRANSACTION {savePointName}");
+                    return;
                 }
+                try { _transaction.Rollback(); }
                 finally { CleanupTransaction(); }
             }
         }


### PR DESCRIPTION
…kTransaction bug (v4.8.2)

## Fixed

### Critical: RollbackTransaction destroyed entire transaction on savepoint rollback Previously, when a savepoint was active, RollbackTransaction issued the ROLLBACK TRANSACTION <savepoint> command but then unconditionally called CleanupTransaction() in a finally block, which disposed the entire outer transaction and cleared the savepoint stack. This meant that nested rollback not only undid the work since the savepoint but also rolled back the entire transaction.

Now, savepoint rollback returns early without disposing the outer transaction (mirroring the behaviour of CommitTransaction).

### ConnectionManager now opens external connections when needed Previously, when an external IDbConnection was supplied (via DapperServiceFactory.Create(IDbConnection)), the connection was returned as-is even if it was in Closed state. This caused BeginTransaction and CRUD operations to throw InvalidOperationException because the connection was not open.

Now GetOpenConnection() and GetOpenConnectionAsync() open external connections that are not yet open, without taking ownership of their lifetime (external connections are still not closed or disposed).

## Added (84 new tests, total 157)

### Test infrastructure (no real database required)
- SpyDbConnection: a test-only IDbConnection that records all executed commands without contacting a real database. Allows asserting on the exact SQL text and parameters that Dapper would have sent.
- ListDataReader<T>: a test-only IDataReader that wraps a list of objects, useful for tests that need to simulate result sets.

### DapperService tests
- DapperServiceConstructorTests (8 tests): constructor validation, disposal semantics, external connection handling
- DapperServiceTransactionTests (10 tests): TransactionCount, Begin/ Commit/Rollback, savepoint nesting, error conditions
- DapperServiceCrudTests (16 tests): Insert/Update/Delete/GetById with SQL assertion via spy connection, composite key handling, attach/ detach change tracking, list operations
- DapperSpyCompatibilityTests (3 tests): verifies Dapper works with the spy IDbConnection

### QueryCache tests (17 tests)
- SQL generation for Insert/Update/Delete/GetById
- Primary key and identity property resolution
- Column name mapping (with and without ColumnAttribute)
- Identifier sanitisation
- Cache identity (same instance returned for same type)

### StoredProcedureExecutor validation tests (30 theory cases)
- Null/empty/whitespace name validation
- Invalid characters (semicolons, quotes, comments, spaces)
- Valid names (schema.procedure, bare names)

## Test results
- All 157 unit tests pass on net8.0.
- Library builds successfully for both net45 and netstandard2.0.
- No real database connection required for any test.