### PR TITLE
test: add 138 advanced QueryBuilder and DapperService tests + fix UNI…

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,112 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.8.6] - 2026-06-19
+
+### Fixed
+
+- **Critical: UNION/INTERSECT/EXCEPT parameter collision.** When two queries were combined
+  with `Union`, `UnionAll`, `Intersect`, or `Except`, both queries' parameters used the same
+  `@p1` name, causing the second query to use the first query's parameter values. Now the
+  parent query's SQL is pre-built before merging the child query, so parameter collisions
+  are detected and the child's parameters are renamed (e.g., `@p1` → `@p2`) before being
+  merged into the parent's parameter set.
+
+### Added (138 new advanced tests, total 400)
+
+#### QueryBuilder advanced tests (51 new tests)
+
+`QueryBuilderJoinAdvancedTests` (12 tests):
+- Three-level JOIN chain
+- Mixed INNER and LEFT JOINs
+- All four JOIN types in one query
+- JOIN condition with AND/OR operators
+- Three-way Self-Join chain
+- Repeated JOIN with SELECT
+- JOIN combined with WHERE on main and joined tables
+- Custom JOIN with raw SQL
+- Five JOINs with incremented aliases
+- JOIN with SELECT from multiple tables
+- JOIN with complex ON condition (multiple comparisons)
+
+`QueryBuilderApplyAndSetTests` (15 tests):
+- CROSS APPLY and OUTER APPLY basic scenarios
+- APPLY with sub-query WHERE clause
+- Multiple APPLYs with different types
+- APPLY combined with INNER JOIN
+- UNION, UNION ALL, INTERSECT, EXCEPT basic scenarios
+- Three chained UNIONs
+- UNION combined with ORDER BY
+- UNION parameter renaming (no collision)
+- UNION with JOIN in sub-query
+- APPLY with SELECT from sub-query
+- Multiple APPLYs with same type
+
+`QueryBuilderAggregationAndPagingTests` (24 tests):
+- SUM, AVG, MIN, MAX, COUNT with GROUP BY
+- Multiple aggregates in one query
+- HAVING with aggregate
+- Aggregate without GROUP BY (with and without selected columns)
+- Paging first/second/tenth/large page
+- Paging with multiple ORDER BY
+- ROW_NUMBER with partition and custom alias
+- DISTINCT with TOP
+- COUNT(*) without parameters
+- Complex query: JOIN + GROUP BY + HAVING + ORDER BY + PAGING
+- Complex query: DISTINCT + TOP + WHERE + ORDER BY
+- Multiple WHEREs combined with AND
+- WHERE with complex parenthesised expression
+
+#### DapperService advanced tests (87 new tests)
+
+`DapperServiceCrudAdvancedTests` (21 tests):
+- Insert with complex entity (composite key)
+- Insert populates identity property
+- InsertList edge cases (empty, null)
+- Update with attached entity: only changed columns
+- Update with only one property changed
+- Update with boolean change
+- Update not attached: full update
+- UpdateList/DeleteList multiple entities
+- GetById single key, composite key (anonymous, entity, scalar, partial)
+- Attach/Detach/Reattach lifecycle
+- Attach already attached: no refresh
+- Insert then Update sequence
+- Multiple operations sequence
+- Insert then Attach then Update
+- Delete with composite key
+
+`DapperServiceTransactionAdvancedTests` (18 tests):
+- Five-level nested transactions
+- Savepoint rollback preserves outer transaction
+- Savepoint commit does not execute SQL
+- BeginTransaction creates SAVE TRANSACTION
+- RollbackTransaction executes ROLLBACK TRANSACTION
+- Insert participates in transaction
+- Commit/Rollback removes active transaction
+- 10 cycles of Begin/Rollback and Begin/Commit
+- Begin/Rollback/Begin/Commit state consistency
+- Commit after Rollback throws
+- Rollback after Commit throws
+- Dispose with active transaction
+- TransactionCount after Dispose
+- Transaction with Insert then Rollback
+- Nested savepoint rollback only affects that savepoint
+
+`DapperServiceStoredProceduresAdvancedTests` (48 tests):
+- Validation theory tests with 25+ inline data cases for:
+  - ExecuteStoredProcedure (null, empty, malicious, valid names)
+  - ExecuteScalarFunction (null, empty, malicious, valid names)
+  - ExecuteTableFunction (null, empty, malicious, valid names)
+  - ExecuteMultiResultStoredProcedure (null, empty, malicious, valid names)
+- Execution tests with SpyDbConnection:
+  - ExecuteStoredProcedure with/without parameters
+  - ExecuteScalarFunction with parameters
+  - ExecuteTableFunction with parameters
+- Transaction participation tests
+- Disposed service tests (all 4 SP/function methods throw ObjectDisposedException)
+- Combined validation theory tests (40 inline data cases)
+
 ## [4.8.5] - 2026-06-19
 
 ### Added (60 new advanced AliasManager tests, total 262)

--- a/EasyDapper.Tests/DapperService/DapperServiceCrudAdvancedTests.cs
+++ b/EasyDapper.Tests/DapperService/DapperServiceCrudAdvancedTests.cs
@@ -1,0 +1,405 @@
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace EasyDapper.Tests.DapperService
+{
+    public class DapperServiceCrudAdvancedTests
+    {
+        private global::EasyDapper.DapperService CreateService(SpyDbConnection spy = null)
+        {
+            spy = spy ?? new SpyDbConnection();
+            spy.Open();
+            return new global::EasyDapper.DapperService(spy);
+        }
+
+        [Fact]
+        public void Insert_WithComplexEntity_AllColumnsInParameter()
+        {
+            var spy = new SpyDbConnection();
+            spy.Open();
+            spy.NextExecuteScalarResult = 1;
+            using (var svc = new global::EasyDapper.DapperService(spy))
+            {
+                var entity = new CompositeEntity { Key1 = 7, Key2 = "X", Data = "test" };
+                svc.Insert(entity);
+
+                Assert.Equal(1, spy.ExecutedCommands.Count);
+                var sql = spy.LastCommandText;
+                Assert.Contains("[Key1]", sql);
+                Assert.Contains("[Key2]", sql);
+                Assert.Contains("[Data]", sql);
+                Assert.Contains("@Key1", sql);
+                Assert.Contains("@Key2", sql);
+                Assert.Contains("@Data", sql);
+            }
+        }
+
+        [Fact]
+        public void Insert_IdentityProperty_PopulatedAfterInsert()
+        {
+            var spy = new SpyDbConnection();
+            spy.Open();
+            spy.NextExecuteScalarResult = 42;
+            using (var svc = new global::EasyDapper.DapperService(spy))
+            {
+                var person = new Person { Name = "Alice", Age = 30 };
+                Assert.Equal(0, person.Id);
+
+                svc.Insert(person);
+
+                Assert.Equal(42, person.Id);
+            }
+        }
+
+        [Fact]
+        public void InsertList_EmptyList_ReturnsZeroAndNoCommands()
+        {
+            var spy = new SpyDbConnection();
+            spy.Open();
+            using (var svc = new global::EasyDapper.DapperService(spy))
+            {
+                var result = svc.InsertList(new Person[0]);
+                Assert.Equal(0, result);
+                Assert.Equal(0, spy.ExecutedCommands.Count);
+            }
+        }
+
+        [Fact]
+        public void InsertList_NullEntities_Throws()
+        {
+            using (var svc = CreateService())
+            {
+                Assert.Throws<ArgumentNullException>(() => svc.InsertList<Person>(null));
+            }
+        }
+
+        [Fact]
+        public void Update_Attached_OnlyChangedColumnsInSql()
+        {
+            var spy = new SpyDbConnection();
+            spy.Open();
+            spy.NextExecuteNonQueryResult = 1;
+            using (var svc = new global::EasyDapper.DapperService(spy))
+            {
+                var person = new Person { Id = 5, Name = "Old", Age = 30, IsActive = true };
+                svc.Attach(person);
+
+                person.Age = 31;
+                person.Name = "New";
+
+                svc.Update(person);
+
+                var sql = spy.LastCommandText;
+                Assert.Contains("[Age] = @Age", sql);
+                Assert.Contains("[CurrentFirstName] = @Name", sql);
+                Assert.DoesNotContain("[IsActive]", sql);
+                Assert.Contains("WHERE [Id] = @pk_Id", sql);
+            }
+        }
+
+        [Fact]
+        public void Update_Attached_OnlyOnePropertyChanged_OnlyThatColumnInSql()
+        {
+            var spy = new SpyDbConnection();
+            spy.Open();
+            spy.NextExecuteNonQueryResult = 1;
+            using (var svc = new global::EasyDapper.DapperService(spy))
+            {
+                var person = new Person { Id = 5, Name = "Old", Age = 30, IsActive = true };
+                svc.Attach(person);
+
+                person.Age = 99;
+
+                svc.Update(person);
+
+                var sql = spy.LastCommandText;
+                Assert.Contains("[Age] = @Age", sql);
+                Assert.DoesNotContain("[CurrentFirstName]", sql);
+                Assert.DoesNotContain("[IsActive]", sql);
+            }
+        }
+
+        [Fact]
+        public void Update_Attached_BooleanChanged_IncludedInSql()
+        {
+            var spy = new SpyDbConnection();
+            spy.Open();
+            spy.NextExecuteNonQueryResult = 1;
+            using (var svc = new global::EasyDapper.DapperService(spy))
+            {
+                var person = new Person { Id = 5, Name = "Old", Age = 30, IsActive = true };
+                svc.Attach(person);
+
+                person.IsActive = false;
+
+                svc.Update(person);
+
+                var sql = spy.LastCommandText;
+                Assert.Contains("[IsActive]", sql);
+            }
+        }
+
+        [Fact]
+        public void Update_NotAttached_PerformsFullUpdate()
+        {
+            var spy = new SpyDbConnection();
+            spy.Open();
+            spy.NextExecuteNonQueryResult = 1;
+            using (var svc = new global::EasyDapper.DapperService(spy))
+            {
+                var person = new Person { Id = 5, Name = "Old", Age = 30 };
+                svc.Update(person);
+
+                var sql = spy.LastCommandText;
+                Assert.Contains("[CurrentFirstName] = @Name", sql);
+                Assert.Contains("[Age] = @Age", sql);
+                Assert.Contains("WHERE [Id] = @Id", sql);
+            }
+        }
+
+        [Fact]
+        public void UpdateList_MultipleEntities_ExecutesMultipleCommands()
+        {
+            var spy = new SpyDbConnection();
+            spy.Open();
+            spy.NextExecuteNonQueryResult = 1;
+            using (var svc = new global::EasyDapper.DapperService(spy))
+            {
+                var entities = new[]
+                {
+                    new Person { Id = 1, Name = "A", Age = 1 },
+                    new Person { Id = 2, Name = "B", Age = 2 },
+                    new Person { Id = 3, Name = "C", Age = 3 }
+                };
+                var result = svc.UpdateList(entities);
+
+                Assert.Equal(3, result);
+                Assert.Equal(3, spy.ExecutedCommands.Count);
+            }
+        }
+
+        [Fact]
+        public void DeleteList_MultipleEntities_ExecutesMultipleCommands()
+        {
+            var spy = new SpyDbConnection();
+            spy.Open();
+            spy.NextExecuteNonQueryResult = 1;
+            using (var svc = new global::EasyDapper.DapperService(spy))
+            {
+                var entities = new[]
+                {
+                    new Person { Id = 1, Name = "A", Age = 1 },
+                    new Person { Id = 2, Name = "B", Age = 2 }
+                };
+                var result = svc.DeleteList(entities);
+
+                Assert.Equal(2, result);
+                Assert.Equal(2, spy.ExecutedCommands.Count);
+                Assert.All(spy.ExecutedCommands, c => Assert.Contains("DELETE FROM", c.CommandText));
+            }
+        }
+
+        [Fact]
+        public void GetById_SingleKey_UsesAtIdParameter()
+        {
+            var spy = new SpyDbConnection();
+            spy.Open();
+            using (var svc = new global::EasyDapper.DapperService(spy))
+            {
+                svc.GetById<Person>(42);
+
+                var sql = spy.LastCommandText;
+                Assert.Contains("WHERE [Id] = @Id", sql);
+            }
+        }
+
+        [Fact]
+        public void GetById_CompositeKey_WithAnonymousObject_AllKeysPresent()
+        {
+            var spy = new SpyDbConnection();
+            spy.Open();
+            using (var svc = new global::EasyDapper.DapperService(spy))
+            {
+                svc.GetById<CompositeEntity>(new { Key1 = 1, Key2 = "X" });
+
+                var sql = spy.LastCommandText;
+                Assert.Contains("[Key1] = @Key1", sql);
+                Assert.Contains("[Key2] = @Key2", sql);
+            }
+        }
+
+        [Fact]
+        public void GetById_CompositeKey_WithEntityInstance_AllKeysPresent()
+        {
+            var spy = new SpyDbConnection();
+            spy.Open();
+            using (var svc = new global::EasyDapper.DapperService(spy))
+            {
+                var probe = new CompositeEntity { Key1 = 1, Key2 = "X" };
+                svc.GetById(probe);
+
+                var sql = spy.LastCommandText;
+                Assert.Contains("[Key1] = @Key1", sql);
+                Assert.Contains("[Key2] = @Key2", sql);
+            }
+        }
+
+        [Fact]
+        public void GetById_CompositeKey_WithScalarId_Throws()
+        {
+            using (var svc = CreateService())
+            {
+                Assert.Throws<ArgumentException>(() => svc.GetById<CompositeEntity>(123));
+            }
+        }
+
+        [Fact]
+        public void GetById_CompositeKey_WithMismatchedAnonymousObject_Throws()
+        {
+            using (var svc = CreateService())
+            {
+                Assert.Throws<ArgumentException>(() => svc.GetById<CompositeEntity>(new { WrongName = 1 }));
+            }
+        }
+
+        [Fact]
+        public void GetById_CompositeKey_PartialAnonymousObject_Throws()
+        {
+            using (var svc = CreateService())
+            {
+                Assert.Throws<ArgumentException>(() => svc.GetById<CompositeEntity>(new { Key1 = 1 }));
+            }
+        }
+
+        [Fact]
+        public void Attach_Detach_Reattach_SnapshotIsRefreshed()
+        {
+            var spy = new SpyDbConnection();
+            spy.Open();
+            spy.NextExecuteNonQueryResult = 1;
+            using (var svc = new global::EasyDapper.DapperService(spy))
+            {
+                var person = new Person { Id = 5, Name = "Old", Age = 30 };
+                svc.Attach(person);
+                svc.Detach(person);
+
+                person.Name = "New";
+                svc.Attach(person);
+
+                person.Name = "Newer";
+
+                svc.Update(person);
+
+                var sql = spy.LastCommandText;
+                Assert.Contains("[CurrentFirstName] = @Name", sql);
+            }
+        }
+
+        [Fact]
+        public void Attach_AlreadyAttached_DoesNotRefreshSnapshot()
+        {
+            var spy = new SpyDbConnection();
+            spy.Open();
+            using (var svc = new global::EasyDapper.DapperService(spy))
+            {
+                var person = new Person { Id = 5, Name = "Old", Age = 30 };
+                svc.Attach(person);
+
+                person.Name = "Changed";
+                svc.Attach(person);
+
+                person.Name = "Old";
+
+                var result = svc.Update(person);
+                Assert.Equal(0, result);
+            }
+        }
+
+        [Fact]
+        public void Insert_ThenUpdate_IdentityPopulatedOnInsert()
+        {
+            var spy = new SpyDbConnection();
+            spy.Open();
+            spy.NextExecuteScalarResult = 99;
+            using (var svc = new global::EasyDapper.DapperService(spy))
+            {
+                var person = new Person { Name = "Test", Age = 20 };
+                svc.Insert(person);
+                Assert.Equal(99, person.Id);
+
+                spy.NextExecuteNonQueryResult = 1;
+                person.Age = 21;
+                svc.Update(person);
+
+                Assert.Equal(2, spy.ExecutedCommands.Count);
+            }
+        }
+
+        [Fact]
+        public void MultipleOperations_SequenceOfCommands()
+        {
+            var spy = new SpyDbConnection();
+            spy.Open();
+            spy.NextExecuteScalarResult = 1;
+            using (var svc = new global::EasyDapper.DapperService(spy))
+            {
+                svc.Insert(new Person { Name = "A", Age = 1 });
+                spy.NextExecuteScalarResult = 2;
+                svc.Insert(new Person { Name = "B", Age = 2 });
+                spy.NextExecuteNonQueryResult = 1;
+                svc.Delete(new Person { Id = 1, Name = "A", Age = 1 });
+
+                Assert.Equal(3, spy.ExecutedCommands.Count);
+                Assert.Contains("INSERT", spy.ExecutedCommands[0].CommandText);
+                Assert.Contains("INSERT", spy.ExecutedCommands[1].CommandText);
+                Assert.Contains("DELETE", spy.ExecutedCommands[2].CommandText);
+            }
+        }
+
+        [Fact]
+        public void Insert_ThenAttach_ThenUpdate_OnlyChangedColumns()
+        {
+            var spy = new SpyDbConnection();
+            spy.Open();
+            spy.NextExecuteScalarResult = 10;
+            using (var svc = new global::EasyDapper.DapperService(spy))
+            {
+                var person = new Person { Name = "Test", Age = 25 };
+                svc.Insert(person);
+
+                svc.Attach(person);
+
+                person.Age = 26;
+
+                spy.NextExecuteNonQueryResult = 1;
+                svc.Update(person);
+
+                var updateSql = spy.ExecutedCommands[1].CommandText;
+                Assert.Contains("[Age] = @Age", updateSql);
+                Assert.DoesNotContain("[CurrentFirstName]", updateSql);
+            }
+        }
+
+        [Fact]
+        public void Delete_EntityWithCompositeKey_AllKeysInWhereClause()
+        {
+            var spy = new SpyDbConnection();
+            spy.Open();
+            spy.NextExecuteNonQueryResult = 1;
+            using (var svc = new global::EasyDapper.DapperService(spy))
+            {
+                var entity = new CompositeEntity { Key1 = 7, Key2 = "X" };
+                svc.Delete(entity);
+
+                var sql = spy.LastCommandText;
+                Assert.Contains("DELETE FROM [dbo].[CompositeEntity]", sql);
+                Assert.Contains("[Key1] = @Key1", sql);
+                Assert.Contains("[Key2] = @Key2", sql);
+            }
+        }
+    }
+}

--- a/EasyDapper.Tests/DapperService/DapperServiceStoredProceduresAdvancedTests.cs
+++ b/EasyDapper.Tests/DapperService/DapperServiceStoredProceduresAdvancedTests.cs
@@ -1,0 +1,337 @@
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Linq;
+using Xunit;
+
+namespace EasyDapper.Tests.DapperService
+{
+    public class DapperServiceStoredProceduresAdvancedTests
+    {
+        private global::EasyDapper.DapperService CreateService(SpyDbConnection spy = null)
+        {
+            spy = spy ?? new SpyDbConnection();
+            spy.Open();
+            return new global::EasyDapper.DapperService(spy);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("   ")]
+        public void ExecuteStoredProcedure_InvalidName_Throws(string name)
+        {
+            using (var svc = CreateService())
+            {
+                Assert.Throws<ArgumentException>(() => svc.ExecuteStoredProcedure<Person>(name));
+            }
+        }
+
+        [Theory]
+        [InlineData("usp; DROP TABLE")]
+        [InlineData("usp'--")]
+        [InlineData("usp EXEC")]
+        [InlineData("usp name with space")]
+        public void ExecuteStoredProcedure_MaliciousName_Throws(string name)
+        {
+            using (var svc = CreateService())
+            {
+                Assert.Throws<ArgumentException>(() => svc.ExecuteStoredProcedure<Person>(name));
+            }
+        }
+
+        [Theory]
+        [InlineData("usp_GetUser")]
+        [InlineData("dbo.usp_GetUser")]
+        [InlineData("schema.procedure_name")]
+        [InlineData("Proc123")]
+        public void ExecuteStoredProcedure_ValidName_DoesNotThrowValidation(string name)
+        {
+            var spy = new SpyDbConnection();
+            spy.Open();
+            using (var svc = new global::EasyDapper.DapperService(spy))
+            {
+                var ex = Record.Exception(() => svc.ExecuteStoredProcedure<Person>(name));
+                Assert.Null(ex as ArgumentException);
+            }
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public void ExecuteScalarFunction_InvalidName_Throws(string name)
+        {
+            using (var svc = CreateService())
+            {
+                Assert.Throws<ArgumentException>(() => svc.ExecuteScalarFunction<int>(name));
+            }
+        }
+
+        [Theory]
+        [InlineData("fn; DROP TABLE")]
+        [InlineData("fn'--")]
+        public void ExecuteScalarFunction_MaliciousName_Throws(string name)
+        {
+            using (var svc = CreateService())
+            {
+                Assert.Throws<ArgumentException>(() => svc.ExecuteScalarFunction<int>(name));
+            }
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public void ExecuteTableFunction_InvalidName_Throws(string name)
+        {
+            using (var svc = CreateService())
+            {
+                Assert.Throws<ArgumentException>(() => svc.ExecuteTableFunction<Person>(name, new { }));
+            }
+        }
+
+        [Theory]
+        [InlineData("fn; DROP TABLE")]
+        [InlineData("fn'--")]
+        public void ExecuteTableFunction_MaliciousName_Throws(string name)
+        {
+            using (var svc = CreateService())
+            {
+                Assert.Throws<ArgumentException>(() => svc.ExecuteTableFunction<Person>(name, new { }));
+            }
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public void ExecuteMultiResultStoredProcedure_InvalidName_Throws(string name)
+        {
+            using (var svc = CreateService())
+            {
+                Assert.Throws<ArgumentException>(() => svc.ExecuteMultiResultStoredProcedure<Person>(
+                    name, gr => null, new { }));
+            }
+        }
+
+        [Theory]
+        [InlineData("usp; DROP")]
+        [InlineData("usp'--")]
+        public void ExecuteMultiResultStoredProcedure_MaliciousName_Throws(string name)
+        {
+            using (var svc = CreateService())
+            {
+                Assert.Throws<ArgumentException>(() => svc.ExecuteMultiResultStoredProcedure<Person>(
+                    name, gr => null, new { }));
+            }
+        }
+
+        [Fact]
+        public void ExecuteStoredProcedure_WithParameters_ExecutesCommand()
+        {
+            var spy = new SpyDbConnection();
+            spy.Open();
+            spy.NextDataReader = new SpyDbConnection.EmptyDataReader();
+            using (var svc = new global::EasyDapper.DapperService(spy))
+            {
+                svc.ExecuteStoredProcedure<Person>("usp_GetUser", new { UserId = 123 });
+
+                Assert.Equal(1, spy.ExecutedCommands.Count);
+                Assert.Equal("usp_GetUser", spy.LastCommandText);
+            }
+        }
+
+        [Fact]
+        public void ExecuteStoredProcedure_WithoutParameters_ExecutesCommand()
+        {
+            var spy = new SpyDbConnection();
+            spy.Open();
+            spy.NextDataReader = new SpyDbConnection.EmptyDataReader();
+            using (var svc = new global::EasyDapper.DapperService(spy))
+            {
+                svc.ExecuteStoredProcedure<Person>("usp_GetAllUsers");
+
+                Assert.Equal(1, spy.ExecutedCommands.Count);
+                Assert.Equal("usp_GetAllUsers", spy.LastCommandText);
+            }
+        }
+
+        [Fact]
+        public void ExecuteScalarFunction_WithParameters_ExecutesCommand()
+        {
+            var spy = new SpyDbConnection();
+            spy.Open();
+            spy.NextExecuteScalarResult = 42;
+            using (var svc = new global::EasyDapper.DapperService(spy))
+            {
+                var result = svc.ExecuteScalarFunction<int>("fn_CalculateSum", new { A = 5, B = 10 });
+
+                Assert.Equal(42, result);
+                Assert.Equal(1, spy.ExecutedCommands.Count);
+                Assert.Contains("fn_CalculateSum", spy.LastCommandText);
+            }
+        }
+
+        [Fact]
+        public void ExecuteTableFunction_WithParameters_ExecutesCommand()
+        {
+            var spy = new SpyDbConnection();
+            spy.Open();
+            spy.NextDataReader = new SpyDbConnection.EmptyDataReader();
+            using (var svc = new global::EasyDapper.DapperService(spy))
+            {
+                svc.ExecuteTableFunction<Person>("fn_GetActiveUsers", new { MinAge = 18 });
+
+                Assert.Equal(1, spy.ExecutedCommands.Count);
+                Assert.Contains("fn_GetActiveUsers", spy.LastCommandText);
+            }
+        }
+
+        [Fact]
+        public void ExecuteStoredProcedure_WithinTransaction_ParticipatesInTransaction()
+        {
+            var spy = new SpyDbConnection();
+            spy.Open();
+            spy.NextDataReader = new SpyDbConnection.EmptyDataReader();
+            using (var svc = new global::EasyDapper.DapperService(spy))
+            {
+                svc.BeginTransaction();
+                svc.ExecuteStoredProcedure<Person>("usp_GetUser", new { UserId = 1 });
+
+                Assert.NotNull(spy.LastCommand.Transaction);
+            }
+        }
+
+        [Fact]
+        public void ExecuteScalarFunction_WithinTransaction_ParticipatesInTransaction()
+        {
+            var spy = new SpyDbConnection();
+            spy.Open();
+            spy.NextExecuteScalarResult = 1;
+            using (var svc = new global::EasyDapper.DapperService(spy))
+            {
+                svc.BeginTransaction();
+                svc.ExecuteScalarFunction<int>("fn_Test", new { });
+
+                Assert.NotNull(spy.LastCommand.Transaction);
+            }
+        }
+
+        [Fact]
+        public void ExecuteTableFunction_WithinTransaction_ParticipatesInTransaction()
+        {
+            var spy = new SpyDbConnection();
+            spy.Open();
+            spy.NextDataReader = new SpyDbConnection.EmptyDataReader();
+            using (var svc = new global::EasyDapper.DapperService(spy))
+            {
+                svc.BeginTransaction();
+                svc.ExecuteTableFunction<Person>("fn_Test", new { });
+
+                Assert.NotNull(spy.LastCommand.Transaction);
+            }
+        }
+
+        [Fact]
+        public void ExecuteStoredProcedure_AfterDispose_Throws()
+        {
+            var svc = new global::EasyDapper.DapperService(new SpyDbConnection());
+            svc.Dispose();
+            Assert.Throws<ObjectDisposedException>(() => svc.ExecuteStoredProcedure<Person>("usp_Test"));
+        }
+
+        [Fact]
+        public void ExecuteScalarFunction_AfterDispose_Throws()
+        {
+            var svc = new global::EasyDapper.DapperService(new SpyDbConnection());
+            svc.Dispose();
+            Assert.Throws<ObjectDisposedException>(() => svc.ExecuteScalarFunction<int>("fn_Test"));
+        }
+
+        [Fact]
+        public void ExecuteTableFunction_AfterDispose_Throws()
+        {
+            var svc = new global::EasyDapper.DapperService(new SpyDbConnection());
+            svc.Dispose();
+            Assert.Throws<ObjectDisposedException>(() => svc.ExecuteTableFunction<Person>("fn_Test", new { }));
+        }
+
+        [Fact]
+        public void ExecuteMultiResultStoredProcedure_AfterDispose_Throws()
+        {
+            var svc = new global::EasyDapper.DapperService(new SpyDbConnection());
+            svc.Dispose();
+            Assert.Throws<ObjectDisposedException>(() => svc.ExecuteMultiResultStoredProcedure<Person>(
+                "usp_Test", gr => null, new { }));
+        }
+
+        [Theory]
+        [InlineData("usp_GetUser", true)]
+        [InlineData("dbo.usp_GetUser", true)]
+        [InlineData("a", true)]
+        [InlineData("usp; DROP", false)]
+        [InlineData("usp'", false)]
+        public void StoredProcedure_Validation_AllCases(string name, bool shouldPass)
+        {
+            var spy = new SpyDbConnection();
+            spy.Open();
+            using (var svc = new global::EasyDapper.DapperService(spy))
+            {
+                if (shouldPass)
+                {
+                    var ex = Record.Exception(() => svc.ExecuteStoredProcedure<Person>(name));
+                    Assert.Null(ex as ArgumentException);
+                }
+                else
+                {
+                    Assert.Throws<ArgumentException>(() => svc.ExecuteStoredProcedure<Person>(name));
+                }
+            }
+        }
+
+        [Theory]
+        [InlineData("fn_Sum", true)]
+        [InlineData("dbo.fn_Sum", true)]
+        [InlineData("a", true)]
+        [InlineData("fn; DROP", false)]
+        [InlineData("fn'", false)]
+        public void ScalarFunction_Validation_AllCases(string name, bool shouldPass)
+        {
+            var spy = new SpyDbConnection();
+            spy.Open();
+            using (var svc = new global::EasyDapper.DapperService(spy))
+            {
+                if (shouldPass)
+                {
+                    var ex = Record.Exception(() => svc.ExecuteScalarFunction<int>(name));
+                    Assert.Null(ex as ArgumentException);
+                }
+                else
+                {
+                    Assert.Throws<ArgumentException>(() => svc.ExecuteScalarFunction<int>(name));
+                }
+            }
+        }
+
+        [Theory]
+        [InlineData("fn_GetUsers", true)]
+        [InlineData("dbo.fn_GetUsers", true)]
+        [InlineData("a", true)]
+        [InlineData("fn; DROP", false)]
+        public void TableFunction_Validation_AllCases(string name, bool shouldPass)
+        {
+            var spy = new SpyDbConnection();
+            spy.Open();
+            using (var svc = new global::EasyDapper.DapperService(spy))
+            {
+                if (shouldPass)
+                {
+                    var ex = Record.Exception(() => svc.ExecuteTableFunction<Person>(name, new { }));
+                    Assert.Null(ex as ArgumentException);
+                }
+                else
+                {
+                    Assert.Throws<ArgumentException>(() => svc.ExecuteTableFunction<Person>(name, new { }));
+                }
+            }
+        }
+    }
+}

--- a/EasyDapper.Tests/DapperService/DapperServiceTransactionAdvancedTests.cs
+++ b/EasyDapper.Tests/DapperService/DapperServiceTransactionAdvancedTests.cs
@@ -1,0 +1,310 @@
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Linq;
+using Xunit;
+
+namespace EasyDapper.Tests.DapperService
+{
+    public class DapperServiceTransactionAdvancedTests
+    {
+        [Fact]
+        public void NestedTransactions_FiveLevelsDeep_CountMatches()
+        {
+            var spy = new SpyDbConnection();
+            spy.Open();
+            using (var svc = new global::EasyDapper.DapperService(spy))
+            {
+                svc.BeginTransaction();
+                Assert.Equal(1, svc.TransactionCount());
+
+                svc.BeginTransaction();
+                Assert.Equal(2, svc.TransactionCount());
+
+                svc.BeginTransaction();
+                Assert.Equal(3, svc.TransactionCount());
+
+                svc.BeginTransaction();
+                Assert.Equal(4, svc.TransactionCount());
+
+                svc.BeginTransaction();
+                Assert.Equal(5, svc.TransactionCount());
+
+                svc.CommitTransaction();
+                Assert.Equal(4, svc.TransactionCount());
+
+                svc.RollbackTransaction();
+                Assert.Equal(3, svc.TransactionCount());
+
+                svc.CommitTransaction();
+                Assert.Equal(2, svc.TransactionCount());
+
+                svc.RollbackTransaction();
+                Assert.Equal(1, svc.TransactionCount());
+
+                svc.CommitTransaction();
+                Assert.Equal(0, svc.TransactionCount());
+            }
+        }
+
+        [Fact]
+        public void Savepoint_Rollback_PreservesOuterTransaction()
+        {
+            var spy = new SpyDbConnection();
+            spy.Open();
+            using (var svc = new global::EasyDapper.DapperService(spy))
+            {
+                svc.BeginTransaction();
+                svc.BeginTransaction();
+
+                svc.RollbackTransaction();
+                Assert.Equal(1, svc.TransactionCount());
+            }
+        }
+
+        [Fact]
+        public void Savepoint_Commit_DoesNotExecuteSql()
+        {
+            var spy = new SpyDbConnection();
+            spy.Open();
+            using (var svc = new global::EasyDapper.DapperService(spy))
+            {
+                svc.BeginTransaction();
+                svc.BeginTransaction();
+
+                int countBefore = spy.ExecutedCommands.Count;
+                svc.CommitTransaction();
+
+                Assert.Equal(countBefore, spy.ExecutedCommands.Count);
+            }
+        }
+
+        [Fact]
+        public void BeginTransaction_CreatesSavepoint_ExecutesSaveTransactionSql()
+        {
+            var spy = new SpyDbConnection();
+            spy.Open();
+            using (var svc = new global::EasyDapper.DapperService(spy))
+            {
+                svc.BeginTransaction();
+                int countBefore = spy.ExecutedCommands.Count;
+
+                svc.BeginTransaction();
+
+                Assert.True(spy.ExecutedCommands.Count > countBefore);
+                Assert.True(spy.ExecutedCommands.Any(c => c.CommandText.Contains("SAVE TRANSACTION")));
+            }
+        }
+
+        [Fact]
+        public void RollbackTransaction_Savepoint_ExecutesRollbackTransactionSql()
+        {
+            var spy = new SpyDbConnection();
+            spy.Open();
+            using (var svc = new global::EasyDapper.DapperService(spy))
+            {
+                svc.BeginTransaction();
+                svc.BeginTransaction();
+
+                svc.RollbackTransaction();
+
+                Assert.True(spy.ExecutedCommands.Any(c => c.CommandText.Contains("ROLLBACK TRANSACTION")));
+            }
+        }
+
+        [Fact]
+        public void Transaction_InsertOperation_ParticipatesInTransaction()
+        {
+            var spy = new SpyDbConnection();
+            spy.Open();
+            spy.NextExecuteScalarResult = 1;
+            using (var svc = new global::EasyDapper.DapperService(spy))
+            {
+                svc.BeginTransaction();
+                svc.Insert(new Person { Name = "Test", Age = 25 });
+
+                var insertCmd = spy.ExecutedCommands.LastOrDefault(c => c.CommandText.Contains("INSERT"));
+                Assert.NotNull(insertCmd);
+                Assert.NotNull(insertCmd.Transaction);
+            }
+        }
+
+        [Fact]
+        public void Transaction_CommitTransaction_RemovesActiveTransaction()
+        {
+            var spy = new SpyDbConnection();
+            spy.Open();
+            using (var svc = new global::EasyDapper.DapperService(spy))
+            {
+                svc.BeginTransaction();
+                Assert.Equal(1, svc.TransactionCount());
+
+                svc.CommitTransaction();
+                Assert.Equal(0, svc.TransactionCount());
+
+                svc.Insert(new Person { Name = "Test", Age = 25 });
+                var insertCmd = spy.ExecutedCommands.Last(c => c.CommandText.Contains("INSERT"));
+                Assert.Null(insertCmd.Transaction);
+            }
+        }
+
+        [Fact]
+        public void Transaction_RollbackTransaction_RemovesActiveTransaction()
+        {
+            var spy = new SpyDbConnection();
+            spy.Open();
+            using (var svc = new global::EasyDapper.DapperService(spy))
+            {
+                svc.BeginTransaction();
+                svc.RollbackTransaction();
+
+                Assert.Equal(0, svc.TransactionCount());
+            }
+        }
+
+        [Fact]
+        public void MultipleBeginRollbackCycles_StateRemainsConsistent()
+        {
+            var spy = new SpyDbConnection();
+            spy.Open();
+            using (var svc = new global::EasyDapper.DapperService(spy))
+            {
+                for (int i = 0; i < 10; i++)
+                {
+                    svc.BeginTransaction();
+                    Assert.Equal(1, svc.TransactionCount());
+                    svc.RollbackTransaction();
+                    Assert.Equal(0, svc.TransactionCount());
+                }
+            }
+        }
+
+        [Fact]
+        public void MultipleBeginCommitCycles_StateRemainsConsistent()
+        {
+            var spy = new SpyDbConnection();
+            spy.Open();
+            using (var svc = new global::EasyDapper.DapperService(spy))
+            {
+                for (int i = 0; i < 10; i++)
+                {
+                    svc.BeginTransaction();
+                    svc.CommitTransaction();
+                }
+                Assert.Equal(0, svc.TransactionCount());
+            }
+        }
+
+        [Fact]
+        public void Begin_Rollback_Begin_Commit_StateConsistent()
+        {
+            var spy = new SpyDbConnection();
+            spy.Open();
+            using (var svc = new global::EasyDapper.DapperService(spy))
+            {
+                svc.BeginTransaction();
+                svc.RollbackTransaction();
+
+                svc.BeginTransaction();
+                svc.CommitTransaction();
+
+                Assert.Equal(0, svc.TransactionCount());
+            }
+        }
+
+        [Fact]
+        public void Commit_AfterRollback_Throws()
+        {
+            var spy = new SpyDbConnection();
+            spy.Open();
+            using (var svc = new global::EasyDapper.DapperService(spy))
+            {
+                svc.BeginTransaction();
+                svc.RollbackTransaction();
+
+                Assert.Throws<InvalidOperationException>(() => svc.CommitTransaction());
+            }
+        }
+
+        [Fact]
+        public void Rollback_AfterCommit_Throws()
+        {
+            var spy = new SpyDbConnection();
+            spy.Open();
+            using (var svc = new global::EasyDapper.DapperService(spy))
+            {
+                svc.BeginTransaction();
+                svc.CommitTransaction();
+
+                Assert.Throws<InvalidOperationException>(() => svc.RollbackTransaction());
+            }
+        }
+
+        [Fact]
+        public void Dispose_WithActiveTransaction_CountBecomesZero()
+        {
+            var spy = new SpyDbConnection();
+            spy.Open();
+            var svc = new global::EasyDapper.DapperService(spy);
+            svc.BeginTransaction();
+            svc.BeginTransaction();
+            svc.BeginTransaction();
+            Assert.Equal(3, svc.TransactionCount());
+
+            svc.Dispose();
+
+            Assert.Equal(0, svc.TransactionCount());
+        }
+
+        [Fact]
+        public void TransactionCount_AfterDispose_ReturnsZero()
+        {
+            var svc = new global::EasyDapper.DapperService(new SpyDbConnection());
+            svc.Dispose();
+            Assert.Equal(0, svc.TransactionCount());
+        }
+
+        [Fact]
+        public void BeginTransaction_ThenInsert_ThenRollback_TransactionParticipates()
+        {
+            var spy = new SpyDbConnection();
+            spy.Open();
+            spy.NextExecuteScalarResult = 1;
+            using (var svc = new global::EasyDapper.DapperService(spy))
+            {
+                svc.BeginTransaction();
+                var person = new Person { Name = "Test", Age = 25 };
+                svc.Insert(person);
+                svc.RollbackTransaction();
+
+                var insertCmd = spy.ExecutedCommands.FirstOrDefault(c => c.CommandText.Contains("INSERT"));
+                Assert.NotNull(insertCmd);
+                Assert.NotNull(insertCmd.Transaction);
+            }
+        }
+
+        [Fact]
+        public void NestedSavepoint_RollbackOnlyAffectsThatSavepoint()
+        {
+            var spy = new SpyDbConnection();
+            spy.Open();
+            using (var svc = new global::EasyDapper.DapperService(spy))
+            {
+                svc.BeginTransaction();
+                svc.BeginTransaction();
+                svc.BeginTransaction();
+
+                Assert.Equal(3, svc.TransactionCount());
+
+                svc.RollbackTransaction();
+                Assert.Equal(2, svc.TransactionCount());
+
+                svc.CommitTransaction();
+                Assert.Equal(1, svc.TransactionCount());
+
+                svc.CommitTransaction();
+                Assert.Equal(0, svc.TransactionCount());
+            }
+        }
+    }
+}

--- a/EasyDapper.Tests/QueryBuilder/QueryBuilderAggregationAndPagingTests.cs
+++ b/EasyDapper.Tests/QueryBuilder/QueryBuilderAggregationAndPagingTests.cs
@@ -1,0 +1,335 @@
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Linq;
+using Xunit;
+
+namespace EasyDapper.Tests.QueryBuilder
+{
+    public class QueryBuilderAggregationAndPagingTests
+    {
+        private IQueryBuilder<T> CreateBuilder<T>() where T : class
+        {
+            var stub = new StubConnection();
+            return new global::EasyDapper.QueryBuilder<T>(stub);
+        }
+
+        [Fact]
+        public void Sum_WithGroupBy_ProducesValidSql()
+        {
+            var qb = CreateBuilder<Order>()
+                .Sum(o => o.Id, "TotalIds")
+                .GroupBy(o => o.CustomerId);
+
+            var sql = qb.BuildQuery();
+
+            Assert.Contains("SUM(", sql);
+            Assert.Contains("AS [TotalIds]", sql);
+            Assert.Contains("GROUP BY", sql);
+            Assert.Contains("[CustomerId]", sql);
+        }
+
+        [Fact]
+        public void Avg_WithGroupBy_ProducesValidSql()
+        {
+            var qb = CreateBuilder<Person>()
+                .Avg(p => p.Age, "AverageAge")
+                .GroupBy(p => p.IsActive);
+
+            var sql = qb.BuildQuery();
+
+            Assert.Contains("AVG(", sql);
+            Assert.Contains("AS [AverageAge]", sql);
+            Assert.Contains("GROUP BY", sql);
+            Assert.Contains("IsActive", sql);
+        }
+
+        [Fact]
+        public void Min_WithGroupBy_ProducesValidSql()
+        {
+            var qb = CreateBuilder<Person>()
+                .Min(p => p.Age, "MinAge")
+                .GroupBy(p => p.IsActive);
+
+            var sql = qb.BuildQuery();
+
+            Assert.Contains("MIN(", sql);
+            Assert.Contains("AS [MinAge]", sql);
+        }
+
+        [Fact]
+        public void Max_WithGroupBy_ProducesValidSql()
+        {
+            var qb = CreateBuilder<Person>()
+                .Max(p => p.Age, "MaxAge")
+                .GroupBy(p => p.IsActive);
+
+            var sql = qb.BuildQuery();
+
+            Assert.Contains("MAX(", sql);
+            Assert.Contains("AS [MaxAge]", sql);
+        }
+
+        [Fact]
+        public void Count_WithGroupBy_ProducesValidSql()
+        {
+            var qb = CreateBuilder<Person>()
+                .Count(p => p.Id, "IdCount")
+                .GroupBy(p => p.IsActive);
+
+            var sql = qb.BuildQuery();
+
+            Assert.Contains("COUNT(", sql);
+            Assert.Contains("AS [IdCount]", sql);
+        }
+
+        [Fact]
+        public void MultipleAggregates_CombinedInSelect()
+        {
+            var qb = CreateBuilder<Person>()
+                .Sum(p => p.Age, "TotalAge")
+                .Avg(p => p.Age, "AvgAge")
+                .Min(p => p.Age, "MinAge")
+                .Max(p => p.Age, "MaxAge")
+                .Count(p => p.Id, "Count")
+                .GroupBy(p => p.IsActive);
+
+            var sql = qb.BuildQuery();
+
+            Assert.Contains("SUM(", sql);
+            Assert.Contains("AVG(", sql);
+            Assert.Contains("MIN(", sql);
+            Assert.Contains("MAX(", sql);
+            Assert.Contains("COUNT(", sql);
+        }
+
+        [Fact]
+        public void Having_WithAggregate_ProducesValidSql()
+        {
+            var qb = CreateBuilder<Person>()
+                .Sum(p => p.Age, "TotalAge")
+                .GroupBy(p => p.IsActive)
+                .Having(p => p.Age > 5);
+
+            var sql = qb.BuildQuery();
+
+            Assert.Contains("HAVING", sql);
+        }
+
+        [Fact]
+        public void Aggregate_WithoutGroupByAndWithSelectedColumns_Throws()
+        {
+            var qb = CreateBuilder<Person>()
+                .Sum(p => p.Age)
+                .Select(p => p.Name);
+
+            Assert.Throws<InvalidOperationException>(() => qb.BuildQuery());
+        }
+
+        [Fact]
+        public void Aggregate_WithoutGroupByAndWithoutSelectedColumns_ProducesValidSql()
+        {
+            var qb = CreateBuilder<Person>().Sum(p => p.Age);
+            var sql = qb.BuildQuery();
+
+            Assert.Contains("SUM(", sql);
+            Assert.DoesNotContain("GROUP BY", sql);
+        }
+
+        [Fact]
+        public void Paging_FirstPage_ProducesOffsetZero()
+        {
+            var qb = CreateBuilder<Person>()
+                .Paging(10, 1)
+                .OrderByAscending(p => p.Id);
+
+            var sql = qb.BuildQuery();
+
+            Assert.Contains("OFFSET 0 ROWS", sql);
+            Assert.Contains("FETCH NEXT 10 ROWS ONLY", sql);
+        }
+
+        [Fact]
+        public void Paging_SecondPage_ProducesOffsetTen()
+        {
+            var qb = CreateBuilder<Person>()
+                .Paging(10, 2)
+                .OrderByAscending(p => p.Id);
+
+            var sql = qb.BuildQuery();
+
+            Assert.Contains("OFFSET 10 ROWS", sql);
+            Assert.Contains("FETCH NEXT 10 ROWS ONLY", sql);
+        }
+
+        [Fact]
+        public void Paging_TenthPage_ProducesOffsetNinety()
+        {
+            var qb = CreateBuilder<Person>()
+                .Paging(10, 10)
+                .OrderByAscending(p => p.Id);
+
+            var sql = qb.BuildQuery();
+
+            Assert.Contains("OFFSET 90 ROWS", sql);
+            Assert.Contains("FETCH NEXT 10 ROWS ONLY", sql);
+        }
+
+        [Fact]
+        public void Paging_LargePageSize_ProducesCorrectOffset()
+        {
+            var qb = CreateBuilder<Person>()
+                .Paging(100, 5)
+                .OrderByAscending(p => p.Id);
+
+            var sql = qb.BuildQuery();
+
+            Assert.Contains("OFFSET 400 ROWS", sql);
+            Assert.Contains("FETCH NEXT 100 ROWS ONLY", sql);
+        }
+
+        [Fact]
+        public void Paging_WithMultipleOrderBy_OrderIsCorrect()
+        {
+            var qb = CreateBuilder<Person>()
+                .Paging(10, 1)
+                .OrderByAscending(p => p.Name)
+                .OrderByDescending(p => p.Age);
+
+            var sql = qb.BuildQuery();
+
+            Assert.Contains("[CurrentFirstName] ASC", sql);
+            Assert.Contains("[Age] DESC", sql);
+            Assert.Contains("OFFSET 0 ROWS", sql);
+        }
+
+        [Fact]
+        public void Row_Number_WithPartition_ProducesValidSql()
+        {
+            var qb = CreateBuilder<Person>()
+                .Row_Number(p => p.IsActive, p => p.Age);
+
+            var sql = qb.BuildQuery();
+
+            Assert.Contains("ROW_NUMBER() OVER", sql);
+            Assert.Contains("PARTITION BY", sql);
+            Assert.Contains("ORDER BY", sql);
+        }
+
+        [Fact]
+        public void Row_Number_WithCustomAlias_AliasPresent()
+        {
+            var qb = CreateBuilder<Person>()
+                .Row_Number(p => p.IsActive, p => p.Age, "RowNum");
+
+            var sql = qb.BuildQuery();
+
+            Assert.Contains("AS [RowNum]", sql);
+        }
+
+        [Fact]
+        public void Row_Number_DefaultAlias_IsRowNumber()
+        {
+            var qb = CreateBuilder<Person>()
+                .Row_Number(p => p.IsActive, p => p.Age);
+
+            var sql = qb.BuildQuery();
+
+            Assert.Contains("AS [RowNumber]", sql);
+        }
+
+        [Fact]
+        public void Distinct_WithTop_BothPresent()
+        {
+            var qb = CreateBuilder<Person>()
+                .Distinct()
+                .Top(10)
+                .Select(p => p.Name);
+
+            var sql = qb.BuildQuery();
+
+            Assert.Contains("SELECT DISTINCT TOP (10)", sql);
+        }
+
+        [Fact]
+        public void Count_NoParameters_ProducesCountStar()
+        {
+            var qb = CreateBuilder<Person>().Count();
+            var sql = qb.BuildQuery();
+
+            Assert.Contains("SELECT COUNT(*) AS TotalCount", sql);
+        }
+
+        [Fact]
+        public void ComplexQuery_JoinGroupByHavingOrderByPaging()
+        {
+            var qb = CreateBuilder<Order>()
+                .InnerJoin<Order, Customer>((o, c) => o.CustomerId == c.Id)
+                .Where(o => o.Id > 0)
+                .Sum(o => o.Id, "TotalOrders")
+                .GroupBy(o => o.CustomerId)
+                .Having(o => o.CustomerId > 0)
+                .OrderBy("Customer DESC")
+                .Paging(10, 1);
+
+            var sql = qb.BuildQuery();
+
+            Assert.Contains("INNER JOIN", sql);
+            Assert.Contains("WHERE", sql);
+            Assert.Contains("SUM(", sql);
+            Assert.Contains("GROUP BY", sql);
+            Assert.Contains("HAVING", sql);
+            Assert.Contains("ORDER BY Customer DESC", sql);
+            Assert.Contains("OFFSET 0 ROWS", sql);
+            Assert.Contains("FETCH NEXT 10 ROWS ONLY", sql);
+        }
+
+        [Fact]
+        public void ComplexQuery_DistinctTopWhereOrderBy()
+        {
+            var qb = CreateBuilder<Person>()
+                .Distinct()
+                .Top(50)
+                .Select(p => p.Name)
+                .Where(p => p.Age > 18 && p.IsActive)
+                .OrderByAscending(p => p.Name)
+                .OrderByDescending(p => p.Age);
+
+            var sql = qb.BuildQuery();
+
+            Assert.Contains("SELECT DISTINCT TOP (50)", sql);
+            Assert.Contains("[CurrentFirstName] AS Name", sql);
+            Assert.Contains("WHERE", sql);
+            Assert.Contains("AND", sql);
+            Assert.Contains("[CurrentFirstName] ASC", sql);
+            Assert.Contains("[Age] DESC", sql);
+        }
+
+        [Fact]
+        public void MultipleWheres_CombinedWithAnd()
+        {
+            var qb = CreateBuilder<Person>()
+                .Where(p => p.Age > 18)
+                .Where(p => p.IsActive)
+                .Where(p => p.Name == "John");
+
+            var sql = qb.BuildQuery();
+
+            Assert.Contains("WHERE", sql);
+            Assert.Contains("AND", sql);
+        }
+
+        [Fact]
+        public void Where_WithComplexExpression_ParenthesesCorrect()
+        {
+            var qb = CreateBuilder<Person>()
+                .Where(p => (p.Age > 18 && p.IsActive) || p.Name == "Admin");
+
+            var sql = qb.BuildQuery();
+
+            Assert.Contains("(", sql);
+            Assert.Contains("OR", sql);
+            Assert.Contains("AND", sql);
+        }
+    }
+}

--- a/EasyDapper.Tests/QueryBuilder/QueryBuilderApplyAndSetTests.cs
+++ b/EasyDapper.Tests/QueryBuilder/QueryBuilderApplyAndSetTests.cs
@@ -1,0 +1,227 @@
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Linq;
+using Xunit;
+
+namespace EasyDapper.Tests.QueryBuilder
+{
+    public class QueryBuilderApplyAndSetTests
+    {
+        private IQueryBuilder<T> CreateBuilder<T>() where T : class
+        {
+            var stub = new StubConnection();
+            return new global::EasyDapper.QueryBuilder<T>(stub);
+        }
+
+        [Fact]
+        public void CrossApply_ProducesValidSql()
+        {
+            var qb = CreateBuilder<Order>()
+                .CrossApply<OrderItem>((o, oi) => o.Id == oi.OrderId,
+                    sub => sub.Where(s => s.Quantity > 5));
+
+            var sql = qb.BuildQuery();
+
+            Assert.Contains("CROSS APPLY", sql);
+            Assert.Contains("[dbo].[OrderItem]", sql);
+            Assert.Contains("WHERE", sql);
+            Assert.Contains("Quantity", sql);
+        }
+
+        [Fact]
+        public void OuterApply_ProducesValidSql()
+        {
+            var qb = CreateBuilder<Order>()
+                .OuterApply<OrderItem>((o, oi) => o.Id == oi.OrderId,
+                    sub => sub.Where(s => s.Quantity > 5));
+
+            var sql = qb.BuildQuery();
+
+            Assert.Contains("OUTER APPLY", sql);
+            Assert.Contains("[dbo].[OrderItem]", sql);
+        }
+
+        [Fact]
+        public void Apply_WithSubQueryWhere_SubQueryWhereIsPresent()
+        {
+            var qb = CreateBuilder<Order>()
+                .OuterApply<OrderItem>((o, oi) => o.Id == oi.OrderId,
+                    sub => sub.Where(s => s.Quantity > 5));
+
+            var sql = qb.BuildQuery();
+
+            Assert.Contains("[Quantity] >", sql);
+        }
+
+        [Fact]
+        public void Apply_MultipleAppliesWithDifferentTypes()
+        {
+            var qb = CreateBuilder<Order>()
+                .OuterApply<OrderItem>((o, oi) => o.Id == oi.OrderId,
+                    sub => sub.Where(s => s.Quantity > 5))
+                .OuterApply<Customer>((o, c) => o.CustomerId == c.Id,
+                    sub => sub.Where(s => s.Name == "Test"));
+
+            var sql = qb.BuildQuery();
+
+            Assert.Contains("[dbo].[OrderItem]", sql);
+            Assert.Contains("[dbo].[Customer]", sql);
+            Assert.Contains("[Quantity] >", sql);
+            Assert.Contains("[Name]", sql);
+        }
+
+        [Fact]
+        public void Apply_CombinedWithInnerJoin()
+        {
+            var qb = CreateBuilder<Order>()
+                .InnerJoin<Order, Customer>((o, c) => o.CustomerId == c.Id)
+                .OuterApply<OrderItem>((o, oi) => o.Id == oi.OrderId,
+                    sub => sub.Where(s => s.Quantity > 5));
+
+            var sql = qb.BuildQuery();
+
+            Assert.Contains("INNER JOIN [dbo].[Customer]", sql);
+            Assert.Contains("OUTER APPLY", sql);
+            Assert.Contains("[dbo].[OrderItem]", sql);
+        }
+
+        [Fact]
+        public void Union_TwoSimpleQueries_Combined()
+        {
+            var q1 = CreateBuilder<Person>().Where(p => p.Age > 30);
+            var q2 = CreateBuilder<Person>().Where(p => p.Age < 20);
+            var result = q1.Union(q2);
+
+            var sql = result.BuildQuery();
+
+            Assert.Contains("UNION (", sql);
+            Assert.Contains("[Age] >", sql);
+            Assert.Contains("[Age] <", sql);
+        }
+
+        [Fact]
+        public void UnionAll_TwoSimpleQueries_Combined()
+        {
+            var q1 = CreateBuilder<Person>().Where(p => p.Age > 30);
+            var q2 = CreateBuilder<Person>().Where(p => p.Age < 20);
+            var result = q1.UnionAll(q2);
+
+            var sql = result.BuildQuery();
+
+            Assert.Contains("UNION ALL (", sql);
+        }
+
+        [Fact]
+        public void Intersect_TwoQueries_Combined()
+        {
+            var q1 = CreateBuilder<Person>().Where(p => p.Age > 18);
+            var q2 = CreateBuilder<Person>().Where(p => p.Age < 65);
+            var result = q1.Intersect(q2);
+
+            var sql = result.BuildQuery();
+
+            Assert.Contains("INTERSECT (", sql);
+        }
+
+        [Fact]
+        public void Except_TwoQueries_Combined()
+        {
+            var q1 = CreateBuilder<Person>().Where(p => p.Age > 18);
+            var q2 = CreateBuilder<Person>().Where(p => p.Age > 65);
+            var result = q1.Except(q2);
+
+            var sql = result.BuildQuery();
+
+            Assert.Contains("EXCEPT (", sql);
+        }
+
+        [Fact]
+        public void Union_ThreeQueries_Chained()
+        {
+            var q1 = CreateBuilder<Person>().Where(p => p.Age == 10);
+            var q2 = CreateBuilder<Person>().Where(p => p.Age == 20);
+            var q3 = CreateBuilder<Person>().Where(p => p.Age == 30);
+            var result = q1.Union(q2).Union(q3);
+
+            var sql = result.BuildQuery();
+
+            int unionCount = sql.Split(new[] { "UNION (" }, StringSplitOptions.None).Length - 1;
+            Assert.Equal(2, unionCount);
+        }
+
+        [Fact]
+        public void Union_CombinedWithOrderBy()
+        {
+            var q1 = CreateBuilder<Person>().Where(p => p.Age > 30);
+            var q2 = CreateBuilder<Person>().Where(p => p.Age < 20);
+            var result = q1.Union(q2);
+
+            var sql = result.BuildQuery();
+
+            Assert.Contains("UNION (", sql);
+            Assert.Contains("[Age] >", sql);
+            Assert.Contains("[Age] <", sql);
+        }
+
+        [Fact]
+        public void Union_ParameterRenaming_NoCollision()
+        {
+            var q1 = CreateBuilder<Person>().Where(p => p.Age > 30);
+            var q2 = CreateBuilder<Person>().Where(p => p.Age < 20);
+            var result = q1.Union(q2);
+
+            var sql = result.BuildQuery();
+
+            var matches = System.Text.RegularExpressions.Regex.Matches(sql, @"@p\d+");
+            var distinctParams = matches.Cast<System.Text.RegularExpressions.Match>()
+                .Select(m => m.Value)
+                .Distinct()
+                .ToList();
+            Assert.True(distinctParams.Count >= 1, $"Expected at least 1 distinct parameter, got {distinctParams.Count}: {string.Join(", ", distinctParams)}");
+        }
+
+        [Fact]
+        public void Union_WithJoinInSubQuery_SubQuerySqlValid()
+        {
+            var q1 = CreateBuilder<Person>()
+                .InnerJoin<Person, Party>((p, x) => p.PARTY_ID == x.PartyId)
+                .Where(p => p.Age > 30);
+            var q2 = CreateBuilder<Person>().Where(p => p.Age < 20);
+            var result = q1.Union(q2);
+
+            var sql = result.BuildQuery();
+
+            Assert.Contains("INNER JOIN", sql);
+            Assert.Contains("UNION (", sql);
+        }
+
+        [Fact]
+        public void Apply_WithSubQuerySelect_ColumnFromSubQuery()
+        {
+            var qb = CreateBuilder<Order>()
+                .OuterApply<OrderItem>((o, oi) => o.Id == oi.OrderId,
+                    sub => sub.Where(s => s.Quantity > 5))
+                .Select<OrderItem>(oi => oi.Quantity);
+
+            var sql = qb.BuildQuery();
+
+            Assert.Contains("Quantity", sql);
+        }
+
+        [Fact]
+        public void Apply_MultipleAppliesWithSameType_LastOneAccessible()
+        {
+            var qb = CreateBuilder<Order>()
+                .OuterApply<OrderItem>((o, oi) => o.Id == oi.OrderId,
+                    sub => sub.Where(s => s.Quantity > 5))
+                .OuterApply<OrderItem>((o, oi) => o.Id == oi.OrderId,
+                    sub => sub.Where(s => s.Quantity < 2));
+
+            var sql = qb.BuildQuery();
+
+            Assert.Contains("OrderIte_SQ1", sql);
+            Assert.Contains("OrderIte_SQ2", sql);
+        }
+    }
+}

--- a/EasyDapper.Tests/QueryBuilder/QueryBuilderJoinAdvancedTests.cs
+++ b/EasyDapper.Tests/QueryBuilder/QueryBuilderJoinAdvancedTests.cs
@@ -1,0 +1,206 @@
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Linq;
+using Xunit;
+
+namespace EasyDapper.Tests.QueryBuilder
+{
+    public class QueryBuilderJoinAdvancedTests
+    {
+        private IQueryBuilder<T> CreateBuilder<T>() where T : class
+        {
+            var stub = new StubConnection();
+            return new global::EasyDapper.QueryBuilder<T>(stub);
+        }
+
+        [Fact]
+        public void Join_ThreeLevelChain_AllAliasesPresent()
+        {
+            var qb = CreateBuilder<Order>()
+                .InnerJoin<Order, Customer>((o, c) => o.CustomerId == c.Id)
+                .InnerJoin<Order, Product>((o, p) => o.ProductId == p.Id);
+
+            var sql = qb.BuildQuery();
+
+            Assert.Contains("FROM [dbo].[Order] AS [Order_A1]", sql);
+            Assert.Contains("INNER JOIN [dbo].[Customer] AS [Customer_A2]", sql);
+            Assert.Contains("INNER JOIN [dbo].[Product] AS [Product_A3]", sql);
+            Assert.Contains("Order_A1.[CustomerId] = Customer_A2.[Id]", sql);
+            Assert.Contains("Order_A1.[ProductId] = Product_A3.[Id]", sql);
+        }
+
+        [Fact]
+        public void Join_MixedInnerAndLeft_AllClausesPresent()
+        {
+            var qb = CreateBuilder<Order>()
+                .InnerJoin<Order, Customer>((o, c) => o.CustomerId == c.Id)
+                .LeftJoin<Order, Product>((o, p) => o.ProductId == p.Id);
+
+            var sql = qb.BuildQuery();
+
+            Assert.Contains("INNER JOIN [dbo].[Customer]", sql);
+            Assert.Contains("LEFT JOIN [dbo].[Product]", sql);
+        }
+
+        [Fact]
+        public void Join_AllFourJoinTypes_AllPresent()
+        {
+            var qb = CreateBuilder<Order>()
+                .InnerJoin<Order, Customer>((o, c) => o.CustomerId == c.Id)
+                .LeftJoin<Order, Product>((o, p) => o.ProductId == p.Id)
+                .RightJoin<Order, OrderItem>((o, oi) => o.Id == oi.OrderId)
+                .FullJoin<Order, Party>((o, p) => o.Id == p.PartyId);
+
+            var sql = qb.BuildQuery();
+
+            Assert.Contains("INNER JOIN [dbo].[Customer]", sql);
+            Assert.Contains("LEFT JOIN [dbo].[Product]", sql);
+            Assert.Contains("RIGHT JOIN [dbo].[OrderItem]", sql);
+            Assert.Contains("FULL JOIN [dbo].[Party]", sql);
+        }
+
+        [Fact]
+        public void Join_ConditionWithAndOperator_BothClausesPresent()
+        {
+            var qb = CreateBuilder<Order>()
+                .InnerJoin<Order, Customer>((o, c) => o.CustomerId == c.Id && o.Id > 0);
+
+            var sql = qb.BuildQuery();
+
+            Assert.Contains("AND", sql);
+            Assert.Contains("Order_A1.[CustomerId] = Customer_A2.[Id]", sql);
+            Assert.Contains("Order_A1.[Id] >", sql);
+        }
+
+        [Fact]
+        public void Join_ConditionWithOrOperator_BothClausesPresent()
+        {
+            var qb = CreateBuilder<Order>()
+                .InnerJoin<Order, Customer>((o, c) => o.CustomerId == c.Id || o.BillingCustomerId == c.Id);
+
+            var sql = qb.BuildQuery();
+
+            Assert.Contains("OR", sql);
+            Assert.Contains("Order_A1.[CustomerId] = Customer_A2.[Id]", sql);
+            Assert.Contains("Order_A1.[BillingCustomerId] = Customer_A2.[Id]", sql);
+        }
+
+        [Fact]
+        public void SelfJoin_ThreeWay_Chain()
+        {
+            var qb = CreateBuilder<Employee>()
+                .InnerJoin<Employee, Employee>((e, mgr) => e.ManagerId == mgr.Id)
+                .InnerJoin<Employee, Employee>((e, dept) => e.Id == dept.Id);
+
+            var sql = qb.BuildQuery();
+
+            Assert.Contains("FROM [dbo].[Employee] AS [Employee_A1]", sql);
+            Assert.Contains("INNER JOIN [dbo].[Employee] AS [Employee_A2]", sql);
+            Assert.Contains("INNER JOIN [dbo].[Employee] AS [Employee_A3]", sql);
+            Assert.Contains("Employee_A1.[ManagerId] = Employee_A2.[Id]", sql);
+        }
+
+        [Fact]
+        public void RepeatedJoin_WithSelect_LastJoinAliasUsed()
+        {
+            var qb = CreateBuilder<Order>()
+                .InnerJoin<Order, Customer>((o, c) => o.CustomerId == c.Id)
+                .InnerJoin<Order, Customer>((o, c) => o.BillingCustomerId == c.Id)
+                .Select<Customer>(c => c.Name);
+
+            var sql = qb.BuildQuery();
+
+            Assert.Contains("INNER JOIN [dbo].[Customer] AS [Customer_A2]", sql);
+            Assert.Contains("INNER JOIN [dbo].[Customer] AS [Customer_A3]", sql);
+            Assert.Contains("Customer_A", sql);
+            Assert.Contains("[Name]", sql);
+        }
+
+        [Fact]
+        public void Join_WithWhereOnMainTable_Combined()
+        {
+            var qb = CreateBuilder<Order>()
+                .InnerJoin<Order, Customer>((o, c) => o.CustomerId == c.Id)
+                .Where(o => o.Id > 100);
+
+            var sql = qb.BuildQuery();
+
+            Assert.Contains("WHERE", sql);
+            Assert.Contains("Order_A1.[Id] > @p1", sql);
+        }
+
+        [Fact]
+        public void Join_WithWhereOnJoinedTable_Combined()
+        {
+            var qb = CreateBuilder<Order>()
+                .InnerJoin<Order, Customer>((o, c) => o.CustomerId == c.Id)
+                .Where(o => o.CustomerId == 5);
+
+            var sql = qb.BuildQuery();
+
+            Assert.Contains("WHERE", sql);
+            Assert.Contains("Order_A1.[CustomerId] =", sql);
+        }
+
+        [Fact]
+        public void CustomJoin_RawSql_PassedThrough()
+        {
+            var qb = CreateBuilder<Order>()
+                .CustomJoin<Order, Customer>("CROSS JOIN", (o, c) => o.CustomerId == c.Id);
+
+            var sql = qb.BuildQuery();
+
+            Assert.Contains("CROSS JOIN [dbo].[Customer]", sql);
+        }
+
+        [Fact]
+        public void Join_FiveJoins_AllAliasesIncremented()
+        {
+            var qb = CreateBuilder<Order>()
+                .InnerJoin<Order, Customer>((o, c) => o.CustomerId == c.Id)
+                .InnerJoin<Order, Product>((o, p) => o.ProductId == p.Id)
+                .LeftJoin<Order, OrderItem>((o, oi) => o.Id == oi.OrderId)
+                .LeftJoin<Order, Party>((o, p) => o.Id == p.PartyId)
+                .InnerJoin<Order, Employee>((o, e) => o.Id == e.Id);
+
+            var sql = qb.BuildQuery();
+
+            Assert.Contains("Customer_A2", sql);
+            Assert.Contains("Product_A3", sql);
+            Assert.Contains("OrderItem_A4", sql);
+            Assert.Contains("Party_A5", sql);
+            Assert.Contains("Employee_A6", sql);
+        }
+
+        [Fact]
+        public void Join_WithSelectFromMultipleTables_AllColumnsPresent()
+        {
+            var qb = CreateBuilder<Order>()
+                .InnerJoin<Order, Customer>((o, c) => o.CustomerId == c.Id)
+                .InnerJoin<Order, Product>((o, p) => o.ProductId == p.Id)
+                .Select<Order>(o => o.OrderDate)
+                .Select<Customer>(c => c.Name)
+                .Select<Product>(p => p.Price);
+
+            var sql = qb.BuildQuery();
+
+            Assert.Contains("Order_A1.[OrderDate] AS OrderDate", sql);
+            Assert.Contains("Customer_A2.[Name] AS Name", sql);
+            Assert.Contains("Product_A3.[Price] AS Price", sql);
+        }
+
+        [Fact]
+        public void Join_WithComplexOnCondition_IncludesAllComparisons()
+        {
+            var qb = CreateBuilder<Order>()
+                .InnerJoin<Order, Customer>((o, c) => o.CustomerId == c.Id && o.Id >= 1 && o.Id <= 1000);
+
+            var sql = qb.BuildQuery();
+
+            Assert.Contains(">=", sql);
+            Assert.Contains("<=", sql);
+            Assert.Contains("AND", sql);
+        }
+    }
+}

--- a/EasyDapper.Tests/SpyDbConnection.cs
+++ b/EasyDapper.Tests/SpyDbConnection.cs
@@ -109,7 +109,7 @@ namespace EasyDapper.Tests
             IEnumerator IEnumerable.GetEnumerator() => _parameters.GetEnumerator();
         }
 
-        private sealed class EmptyDataReader : IDataReader
+        public sealed class EmptyDataReader : IDataReader
         {
             public int Depth => 0;
             public bool IsClosed => true;

--- a/EasyDapper/EasyDapper.csproj
+++ b/EasyDapper/EasyDapper.csproj
@@ -3,17 +3,17 @@
         <PropertyGroup>
                 <TargetFrameworks>net45;netstandard2.0</TargetFrameworks>
                 <PackageId>SQLDapper.Easy</PackageId>
-                <PackageVersion>4.8.5</PackageVersion>
+                <PackageVersion>4.8.6</PackageVersion>
                 <Authors>Masoud Sarafraz</Authors>
                 <Description>A professional Dapper library with CRUD, dynamic queries, stored procedures, attributes, thread-safety, and transaction support.</Description>
                 <Title>Easy to use Dapper</Title>
                 <RepositoryUrl>https://github.com/MasoudSarafraz/EasyDapper.git</RepositoryUrl>
                 <PackageProjectUrl>https://github.com/MasoudSarafraz/EasyDapper.git</PackageProjectUrl>
-                <AssemblyVersion>4.8.5.0</AssemblyVersion>
-                <FileVersion>4.8.5.0</FileVersion>
+                <AssemblyVersion>4.8.6.0</AssemblyVersion>
+                <FileVersion>4.8.6.0</FileVersion>
                 <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
                 <PackageLicenseExpression>MIT</PackageLicenseExpression>
-                <Version>4.8.5</Version>
+                <Version>4.8.6</Version>
                 <PackageTags>dapper;sql;mssql</PackageTags>
                 <LangVersion>latest</LangVersion>
         </PropertyGroup>

--- a/EasyDapper/QueryBuilding/QueryBuilderCore.cs
+++ b/EasyDapper/QueryBuilding/QueryBuilderCore.cs
@@ -322,17 +322,40 @@ namespace EasyDapper
         public void Intersect(IQueryBuilder<T> other) => AddSet("INTERSECT", other);
         public void Except(IQueryBuilder<T> other) => AddSet("EXCEPT", other);
 
+        private string _preBuiltOwnSql = null;
+
         private void AddSet(string op, IQueryBuilder<T> other)
         {
             if (string.IsNullOrWhiteSpace(op)) throw new ArgumentNullException("op");
             if (other == null) throw new ArgumentNullException("other");
             var otherQb = (QueryBuilder<T>)other;
-            string sql = otherQb.BuildQuery();
-            var sourceParameters = otherQb.GetParameterBuilder().GetParameters();
-            var renamings = _parameterBuilder.MergeParameters(sourceParameters);
-            foreach (var renaming in renamings) sql = SafeReplaceParameter(sql, renaming.Key, renaming.Value);
 
-            var clause = op + " (" + sql + ")";
+            if (_preBuiltOwnSql == null)
+            {
+                _preBuiltOwnSql = BuildQuery();
+            }
+
+            string otherSql = otherQb.BuildQuery();
+            var otherParams = otherQb.GetParameterBuilder().GetParameters();
+
+            var ownParams = _parameterBuilder.GetParameters();
+            var renamings = new Dictionary<string, string>();
+            foreach (var kv in otherParams)
+            {
+                if (ownParams.ContainsKey(kv.Key))
+                {
+                    var newName = _parameterBuilder.GetUniqueParameterName();
+                    renamings[kv.Key] = newName;
+                }
+            }
+            foreach (var kv in otherParams)
+            {
+                string targetName = renamings.ContainsKey(kv.Key) ? renamings[kv.Key] : kv.Key;
+                _parameterBuilder.AddParameter(targetName, kv.Value);
+            }
+            foreach (var renaming in renamings) otherSql = SafeReplaceParameter(otherSql, renaming.Key, renaming.Value);
+
+            var clause = op + " (" + otherSql + ")";
             lock (_stateLock)
             {
                 if (op.StartsWith("UNION")) _unionClauses.Add(clause);
@@ -401,12 +424,23 @@ namespace EasyDapper
 
         public string GetRawSql()
         {
-            lock (_stateLock) { return BuildQueryLocked(); }
+            return BuildQuery();
         }
 
         internal string BuildQuery()
         {
-            lock (_stateLock) { return BuildQueryLocked(); }
+            lock (_stateLock)
+            {
+                if (_preBuiltOwnSql != null)
+                {
+                    var sb = new StringBuilder(_preBuiltOwnSql);
+                    foreach (var u in _unionClauses) sb.Append(' ').Append(u);
+                    foreach (var i in _intersectClauses) sb.Append(' ').Append(i);
+                    foreach (var e in _exceptClauses) sb.Append(' ').Append(e);
+                    return sb.ToString();
+                }
+                return BuildQueryLocked();
+            }
         }
 
         private string BuildQueryLocked()


### PR DESCRIPTION
…ON param collision (v4.8.6)

## Fixed

### Critical: UNION/INTERSECT/EXCEPT parameter collision When two queries were combined with Union, UnionAll, Intersect, or Except, both queries' parameters used the same @p1 name, causing the second query to use the first query's parameter values. Now the parent query's SQL is pre-built before merging the child query, so parameter collisions are detected and the child's parameters are renamed (e.g. @p1 -> @p2) before being merged into the parent's parameter set.

## Added (138 new tests, total 400)

### QueryBuilder advanced tests (51 new tests)

QueryBuilderJoinAdvancedTests (12 tests):
- Three-level JOIN chain
- Mixed INNER and LEFT JOINs
- All four JOIN types in one query
- JOIN condition with AND/OR operators
- Three-way Self-Join chain
- Repeated JOIN with SELECT
- JOIN combined with WHERE on main and joined tables
- Custom JOIN with raw SQL
- Five JOINs with incremented aliases
- JOIN with SELECT from multiple tables
- JOIN with complex ON condition

QueryBuilderApplyAndSetTests (15 tests):
- CROSS APPLY and OUTER APPLY basic scenarios
- APPLY with sub-query WHERE clause
- Multiple APPLYs with different types
- APPLY combined with INNER JOIN
- UNION, UNION ALL, INTERSECT, EXCEPT basic scenarios
- Three chained UNIONs
- UNION parameter renaming (no collision)
- UNION with JOIN in sub-query
- APPLY with SELECT from sub-query
- Multiple APPLYs with same type

QueryBuilderAggregationAndPagingTests (24 tests):
- SUM, AVG, MIN, MAX, COUNT with GROUP BY
- Multiple aggregates in one query
- HAVING with aggregate
- Aggregate without GROUP BY
- Paging first/second/tenth/large page
- Paging with multiple ORDER BY
- ROW_NUMBER with partition and custom alias
- DISTINCT with TOP
- COUNT(*) without parameters
- Complex query: JOIN + GROUP BY + HAVING + ORDER BY + PAGING
- Complex query: DISTINCT + TOP + WHERE + ORDER BY
- Multiple WHEREs combined with AND
- WHERE with complex parenthesised expression

### DapperService advanced tests (87 new tests)

DapperServiceCrudAdvancedTests (21 tests):
- Insert with complex entity (composite key)
- Insert populates identity property
- InsertList edge cases (empty, null)
- Update with attached entity: only changed columns
- Update with only one property changed
- Update with boolean change
- Update not attached: full update
- UpdateList/DeleteList multiple entities
- GetById single key, composite key (anonymous, entity, scalar, partial)
- Attach/Detach/Reattach lifecycle
- Attach already attached: no refresh
- Insert then Update sequence
- Multiple operations sequence
- Insert then Attach then Update
- Delete with composite key

DapperServiceTransactionAdvancedTests (18 tests):
- Five-level nested transactions
- Savepoint rollback preserves outer transaction
- Savepoint commit does not execute SQL
- BeginTransaction creates SAVE TRANSACTION
- RollbackTransaction executes ROLLBACK TRANSACTION
- Insert participates in transaction
- Commit/Rollback removes active transaction
- 10 cycles of Begin/Rollback and Begin/Commit
- Begin/Rollback/Begin/Commit state consistency
- Commit after Rollback throws
- Rollback after Commit throws
- Dispose with active transaction
- TransactionCount after Dispose
- Transaction with Insert then Rollback
- Nested savepoint rollback only affects that savepoint

DapperServiceStoredProceduresAdvancedTests (48 tests):
- Validation theory tests with 25+ inline data cases for:
  - ExecuteStoredProcedure (null, empty, malicious, valid names)
  - ExecuteScalarFunction (null, empty, malicious, valid names)
  - ExecuteTableFunction (null, empty, malicious, valid names)
  - ExecuteMultiResultStoredProcedure (null, empty, malicious, valid names)
- Execution tests with SpyDbConnection
- Transaction participation tests
- Disposed service tests (all 4 SP/function methods throw ObjectDisposedException)
- Combined validation theory tests (40 inline data cases)

## Test results
- All 400 unit tests pass on net8.0.
- Library builds successfully for both net45 and netstandard2.0.