### PR TITLE
fix: add System.ValueTuple package for net462 tuple support (v4.8.6)

### DIFF
--- a/EasyDapper.Tests/EasyDapper.Tests.csproj
+++ b/EasyDapper.Tests/EasyDapper.Tests.csproj
@@ -15,6 +15,10 @@
     </PackageReference>
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
+    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
+  </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\EasyDapper\EasyDapper.csproj" />
   </ItemGroup>


### PR DESCRIPTION
The AliasManagerAdvancedTests.cs file uses C# tuple syntax (e.g. '(string leftAlias, string rightAlias)') which requires the System.ValueTuple type. On .NET Framework 4.6.2 this type is not available in the BCL (it was added in 4.7), causing two compiler errors:

  CS8137: Cannot define a class or member that utilizes tuples because
          the compiler required type 'TupleElementNamesAttribute'
          cannot be found.
  CS8179: Predefined type 'System.ValueTuple`2' is not defined or imported.

Fix: added a conditional PackageReference to 'System.ValueTuple' 4.5.0 that only applies when TargetFramework == 'net462'. This is the standard NuGet package that backports ValueTuple to .NET Framework 4.5+ and 4.6.1+.

The package is only added to the test project (EasyDapper.Tests), not to the main library (EasyDapper). The main library does not use tuple syntax and continues to target net45 + netstandard2.0 without any additional dependencies.

## Verification
- net462 build: SUCCESS (0 errors, 17 warnings - all xUnit analyzer style)
- net8.0 tests: 400 passed, 0 failed
- net45 main library: SUCCESS
- netstandard2.0 main library: SUCCESS